### PR TITLE
Use singledispatch to generate ptypes and remove save_ptype parameter

### DIFF
--- a/examples/coffeeratings.py
+++ b/examples/coffeeratings.py
@@ -17,7 +17,7 @@ X_train, X_test, y_train, y_test = model_selection.train_test_split(coffee.iloc[
 lr_fit = LinearRegression().fit(X_train, y_train)
 
 # create vetiver model
-v = vetiver.VetiverModel(lr_fit, save_ptype = True, ptype_data=X_train, model_name = "v")
+v = vetiver.VetiverModel(lr_fit, ptype_data=X_train, model_name = "v")
 
 # version model via pin
 from pins import board_folder

--- a/vetiver/handlers/_interface.py
+++ b/vetiver/handlers/_interface.py
@@ -7,7 +7,7 @@ try:
 except ImportError:
     torch_exists = False
 
-def create_translator(model, ptype_data, save_ptype):
+def create_translator(model, ptype_data):
     """check for model type to handle prediction
 
     Parameters
@@ -22,10 +22,10 @@ def create_translator(model, ptype_data, save_ptype):
     """
     if torch_exists:
         if isinstance(model, torch.nn.Module):
-            return pytorch_vt.TorchHandler(model, ptype_data, save_ptype)
+            return pytorch_vt.TorchHandler(model, ptype_data)
 
     if isinstance(model, sklearn.base.BaseEstimator):
-        return sklearn_vt.SKLearnHandler(model, ptype_data, save_ptype)
+        return sklearn_vt.SKLearnHandler(model, ptype_data)
 
     else:
         raise NotImplementedError

--- a/vetiver/handlers/pytorch_vt.py
+++ b/vetiver/handlers/pytorch_vt.py
@@ -65,7 +65,7 @@ class TorchHandler:
         """
         ...
 
-    def handler_predict(self, input_data, check_ptype):
+    def handler_predict(self, input_data, check_ptype, **kw):
         """Generates method for /predict endpoint in VetiverAPI
 
         The `handler_predict` function executes at each API call. Use this
@@ -88,15 +88,10 @@ class TorchHandler:
                 prediction = self.model(torch.from_numpy(input_data))
             
             # do not check ptype
-            else:
-                batch = True
-                if not isinstance(input_data, list):
-                    batch = False
-                    input_data = input_data.split(",")  # user delimiter ?
-                input_data = np.array(input_data, dtype=np.array(self.ptype_data).dtype)
-                if not batch:
-                    input_data = input_data.reshape(1, -1)
-                prediction = self.model(torch.from_numpy(input_data))
+            else:    
+                input_data = torch.tensor(input_data)
+                prediction = self.model(input_data)
+
         else:
             raise ImportError("Cannot import `torch`.")
 

--- a/vetiver/handlers/pytorch_vt.py
+++ b/vetiver/handlers/pytorch_vt.py
@@ -17,10 +17,9 @@ class TorchHandler:
     model : nn.Module
         a trained torch model
     """
-    def __init__(self, model, ptype_data, save_ptype):
+    def __init__(self, model, ptype_data):
         self.model = model
         self.ptype_data = ptype_data
-        self.save_ptype = save_ptype
 
     def create_description(self):
         """Create description for torch model
@@ -48,14 +47,13 @@ class TorchHandler:
         ----------
         ptype_data : pd.DataFrame, np.ndarray, or None
             Training data to create ptype
-        save_ptype : bool
 
         Returns
         -------
         ptype : pd.DataFrame or None
             Zero-row DataFrame for storing data types
         """
-        ptype = vetiver_create_ptype(self.ptype_data, self.save_ptype)
+        ptype = vetiver_create_ptype(self.ptype_data)
 
         return ptype
 

--- a/vetiver/handlers/pytorch_vt.py
+++ b/vetiver/handlers/pytorch_vt.py
@@ -65,7 +65,7 @@ class TorchHandler:
         """
         ...
 
-    def handler_predict(self, input_data, check_ptype, **kw):
+    def handler_predict(self, input_data, check_ptype):
         """Generates method for /predict endpoint in VetiverAPI
 
         The `handler_predict` function executes at each API call. Use this

--- a/vetiver/handlers/sklearn_vt.py
+++ b/vetiver/handlers/sklearn_vt.py
@@ -12,10 +12,9 @@ class SKLearnHandler:
         a trained sklearn model
     """
 
-    def __init__(self, model, ptype_data, save_ptype):
+    def __init__(self, model, ptype_data):
         self.model = model
         self.ptype_data = ptype_data
-        self.save_ptype = save_ptype
 
     def create_description(self):
         """Create description for sklearn model
@@ -42,14 +41,13 @@ class SKLearnHandler:
         ----------
         ptype_data : pd.DataFrame, np.ndarray, or None
             Training data to create ptype
-        save_ptype : bool
 
         Returns
         -------
         ptype : pd.DataFrame or None
             Zero-row DataFrame for storing data types
         """
-        ptype = vetiver_create_ptype(self.ptype_data, self.save_ptype)
+        ptype = vetiver_create_ptype(self.ptype_data)
         return ptype
 
     def handler_startup():

--- a/vetiver/pin_read_write.py
+++ b/vetiver/pin_read_write.py
@@ -29,7 +29,6 @@ def vetiver_pin_write(board, model: VetiverModel, versioned: bool=True):
         type = "joblib",
         description = model.description,
         metadata = {"required_pkgs": model.metadata.get("required_pkgs"),
-                    "save_ptype": model.save_ptype,
                     "ptype": None if model.ptype == None else model.ptype().json()},
         versioned=versioned
     )
@@ -79,7 +78,6 @@ def vetiver_pin_read(board, name: str, version: str = None) -> VetiverModel:
              url = meta.user.get("url"), # None all the time, besides Connect
              required_pkgs = meta.user.get("required_pkgs")
         ),
-        save_ptype=meta.user.get("save_ptype"),
         ptype_data = json.loads(meta.user.get("ptype")) if meta.user.get("ptype") else None,
         versioned = True
         )

--- a/vetiver/ptype.py
+++ b/vetiver/ptype.py
@@ -22,13 +22,12 @@ class NoAvailablePTypeError(Exception):
 
 class InvalidPTypeError(Exception):
     """
-    Throw an error if `save_ptype` is not
-    True, False, or data.frame
+    Throw an error if ptype cannot be recognised
     """
 
     def __init__(
         self,
-        message="The `ptype_data` argument must be a pandas.DataFrame, a pydantic BaseModel,  np.ndarray, or `save_ptype` must be FALSE.",
+        message="`ptype_data` must be a pd.DataFrame, a pydantic BaseModel or np.ndarray",
     ):
         self.message = message
         super().__init__(self.message)
@@ -55,7 +54,7 @@ a pull request.
 """
 
 @singledispatch
-def vetiver_create_ptype(data, save_ptype):
+def vetiver_create_ptype(data):
     """Create zero row structure to save data types
 
     Parameters
@@ -69,20 +68,20 @@ def vetiver_create_ptype(data, save_ptype):
         Data prototype
 
     """
-    msg = CREATE_PTYPE_TPL.format(_data_type=type(data))
-    msg = ""
-    raise InvalidPTypeError(message=msg)
+    raise InvalidPTypeError(
+        message=CREATE_PTYPE_TPL.format(_data_type=type(data))
+    )
 
 
 @vetiver_create_ptype.register
-def _vetiver_create_ptype(data: pd.DataFrame, save_ptype):
+def _vetiver_create_ptype(data: pd.DataFrame):
     dict_data = data.iloc[1, :].to_dict()
     ptype = create_model("ptype", **dict_data)
     return ptype
 
 
 @vetiver_create_ptype.register
-def _vetiver_create_ptype(data: np.ndarray, save_ptype):
+def _vetiver_create_ptype(data: np.ndarray):
     dict_data = dict(enumerate(data[1], 0))
     # pydantic requires strings as indicies
     dict_data = {f"{key}": value.item() for key, value in dict_data.items()}
@@ -91,15 +90,15 @@ def _vetiver_create_ptype(data: np.ndarray, save_ptype):
 
 
 @vetiver_create_ptype.register
-def _vetiver_create_ptype(data: dict, save_ptype):
+def _vetiver_create_ptype(data: dict):
     return create_model("ptype", **data)
 
 
 @vetiver_create_ptype.register
-def _vetiver_create_ptype(data: BaseModel, save_ptype):
+def _vetiver_create_ptype(data: BaseModel):
     return data
 
 
 @vetiver_create_ptype.register
-def _vetiver_create_ptype(data: NoneType, save_ptype):
+def _vetiver_create_ptype(data: NoneType):
     return None

--- a/vetiver/ptype.py
+++ b/vetiver/ptype.py
@@ -1,5 +1,9 @@
 from functools import singledispatch
-from types import NoneType
+try:
+    from types import NoneType
+except ImportError:
+    # python < 3.10
+    NoneType = type(None)
 
 import pandas as pd
 import numpy as np

--- a/vetiver/tests/test_add_endpoint.py
+++ b/vetiver/tests/test_add_endpoint.py
@@ -9,7 +9,6 @@ def _start_application(check_ptype):
     model = mock.get_mock_model().fit(X, y)
     v = VetiverModel(
         model=model,
-        save_ptype=True,
         ptype_data=X,
         model_name="my_model",
         versioned=None,

--- a/vetiver/tests/test_build_api.py
+++ b/vetiver/tests/test_build_api.py
@@ -9,7 +9,6 @@ def _build_v():
     model = mock.get_mock_model().fit(X, y)
     v = VetiverModel(
         model=model,
-        save_ptype=True,
         ptype_data=X,
         model_name="my_model",
         versioned=None,

--- a/vetiver/tests/test_build_vetiver_model.py
+++ b/vetiver/tests/test_build_vetiver_model.py
@@ -16,7 +16,6 @@ def test_vetiver_model_array_ptype():
     # build VetiverModel, no ptype
     vt1 = VetiverModel(
         model=model,
-        save_ptype=True,
         ptype_data=X_array,
         model_name="iris",
         versioned=None,
@@ -32,7 +31,6 @@ def test_vetiver_model_df_ptype():
     # build VetiverModel, df ptype_data
     vt2 = VetiverModel(
         model=model,
-        save_ptype=True,
         ptype_data=X_df,
         model_name="iris",
         versioned=None,
@@ -48,7 +46,6 @@ def test_vetiver_model_dict_ptype():
     dict_data = {"B": 0, "C": 0, "D": 0}
     vt3 = VetiverModel(
         model=model,
-        save_ptype=True,
         ptype_data=dict_data,
         model_name="iris",
         versioned=None,
@@ -64,8 +61,7 @@ def test_vetiver_model_no_ptype():
     # build VetiverModel, no ptype
     vt4 = VetiverModel(
         model=model,
-        save_ptype=False,
-        ptype_data=X_df,
+        ptype_data=None,
         model_name="iris",
         versioned=None,
         description=None,
@@ -74,17 +70,3 @@ def test_vetiver_model_no_ptype():
 
     assert vt4.model == model
     assert vt4.ptype == None
-
-
-def test_vetiver_model_error():
-    with pytest.raises(AttributeError):
-        VetiverModel(
-        model=model,
-        save_ptype=True,
-        ptype_data=None,
-        model_name="iris",
-        versioned=None,
-        description=None,
-        metadata=None,
-    )
-

--- a/vetiver/tests/test_no_handler.py
+++ b/vetiver/tests/test_no_handler.py
@@ -8,7 +8,6 @@ def test_not_implemented_error():
     with pytest.raises(NotImplementedError):
         VetiverModel(
         model=y,
-        save_ptype=True,
         ptype_data=X,
         model_name="my_model",
         versioned=None,

--- a/vetiver/tests/test_pin_read.py
+++ b/vetiver/tests/test_pin_read.py
@@ -4,14 +4,13 @@ from vetiver import vetiver_pin_read, vetiver_pin_write, VetiverModel, VetiverAP
 from fastapi.testclient import TestClient
 import numpy as np
 
-def _make_model(save_ptype: bool):
+def _make_model(save_ptype: bool=True):
     np.random.seed(500)
     X, y = mock.get_mock_data()
     model = mock.get_mock_model().fit(X, y)
     v = VetiverModel(
         model=model,
-        save_ptype=save_ptype,
-        ptype_data=X,
+        ptype_data=X if save_ptype else None,
         model_name="model",
         versioned=None,
         description="A regression model for testing purposes",
@@ -21,7 +20,7 @@ def _make_model(save_ptype: bool):
 
 def test_board_pin_rountrip_ptype_sklearn():
     np.random.seed(500)
-    v = _make_model(save_ptype=True)
+    v = _make_model()
     board = pins.board_temp(allow_pickle_read=True)
     vetiver_pin_write(board=board, model=v)
     v = vetiver_pin_read(board, "model")

--- a/vetiver/tests/test_ping_server.py
+++ b/vetiver/tests/test_ping_server.py
@@ -10,7 +10,6 @@ def _start_application():
     model = mock.get_mock_model().fit(X, y)
     v = VetiverModel(
         model=model,
-        save_ptype=True,
         ptype_data=X,
         model_name="my_model",
         versioned=None,

--- a/vetiver/tests/test_predict.py
+++ b/vetiver/tests/test_predict.py
@@ -14,7 +14,6 @@ def test_predict_sklearn_dict_ptype():
     model = mock.get_mock_model().fit(X, y)
     v = VetiverModel(
         model=model,
-        save_ptype=True,
         ptype_data=X,
         model_name="my_model",
         versioned=None,
@@ -37,7 +36,6 @@ def test_predict_sklearn_no_ptype():
     model = mock.get_mock_model().fit(X, y)
     v = VetiverModel(
         model=model,
-        save_ptype=True,
         ptype_data=X,
         model_name="my_model",
         versioned=None,
@@ -59,7 +57,6 @@ def test_predict_sklearn_df_check_ptype():
     model = mock.get_mock_model().fit(X, y)
     v = VetiverModel(
         model=model,
-        save_ptype=True,
         ptype_data=X,
         model_name="my_model",
         versioned=None,
@@ -82,7 +79,6 @@ def test_predict_sklearn_series_check_ptype():
     model = mock.get_mock_model().fit(X, y)
     v = VetiverModel(
         model=model,
-        save_ptype=True,
         ptype_data=X,
         model_name="my_model",
         versioned=None,
@@ -104,7 +100,6 @@ def test_predict_sklearn_type_error():
     model = mock.get_mock_model().fit(X, y)
     v = VetiverModel(
         model=model,
-        save_ptype=True,
         ptype_data=X,
         model_name="my_model",
         versioned=None,

--- a/vetiver/tests/test_pytorch.py
+++ b/vetiver/tests/test_pytorch.py
@@ -99,17 +99,17 @@ def test_torch_predict_ptype_error():
     assert response.status_code == 422, response.text  # value is not a valid float
 
 
-def test_torch_predict_no_ptype():
+def test_torch_predict_no_ptype_error():
     torch.manual_seed(3)
     x_train, torch_model = _build_torch_v()
-    v = VetiverModel(torch_model, model_name = "torch", ptype_data=x_train)
+    v = VetiverModel(torch_model, model_name = "torch")
     v_api = VetiverAPI(v, check_ptype=False)
 
     client = TestClient(v_api.app)
-    data = "3.3"
+    data =[[3.3], [3.3]]
     response = client.post("/predict/", json=data)
     assert response.status_code == 200, response.text
-    assert response.json() == {"prediction":[[-4.060722351074219]]}, response.text
+    assert response.json() == {"prediction":[[-4.060722351074219],[-4.060722351074219]]}, response.text
 
 
 def test_torch_predict_no_ptype_batch():
@@ -119,18 +119,8 @@ def test_torch_predict_no_ptype_batch():
     v_api = VetiverAPI(v, check_ptype=False)
 
     client = TestClient(v_api.app)
-    data = [["3.3"], ["3.3"]]
+    data = [[3.3]]
     response = client.post("/predict/", json=data)
     assert response.status_code == 200, response.text
-    assert response.json() == {"prediction":[[-4.060722351074219],[-4.060722351074219]]}, response.text
-
-
-def test_torch_predict_no_ptype_error():
-
-    x_train, torch_model = _build_torch_v()
-    v = VetiverModel(torch_model, model_name = "torch")
-    v_api = VetiverAPI(v, check_ptype=False)
-
-    client = TestClient(v_api.app)
-    data = "bad"
+    assert response.json() == {"prediction":[[-4.060722351074219]]}, response.text
 

--- a/vetiver/tests/test_pytorch.py
+++ b/vetiver/tests/test_pytorch.py
@@ -48,7 +48,6 @@ def test_vetiver_build():
 
     vt2 = VetiverModel(
         model=torch_model,
-        save_ptype=True,
         ptype_data=x_train,
         model_name = "torch", 
         versioned=None,
@@ -62,7 +61,7 @@ def test_vetiver_build():
 def test_torch_predict_ptype():
     torch.manual_seed(3)
     x_train, torch_model = _build_torch_v()
-    v = VetiverModel(torch_model, model_name = "torch", save_ptype=True, ptype_data=x_train)
+    v = VetiverModel(torch_model, model_name = "torch", ptype_data=x_train)
     v_api = VetiverAPI(v)
 
     client = TestClient(v_api.app)
@@ -76,7 +75,7 @@ def test_torch_predict_ptype():
 def test_torch_predict_ptype_batch():
     torch.manual_seed(3)
     x_train, torch_model = _build_torch_v()
-    v = VetiverModel(torch_model, model_name = "torch", save_ptype=True, ptype_data=x_train)
+    v = VetiverModel(torch_model, model_name = "torch", ptype_data=x_train)
     v_api = VetiverAPI(v)
 
     client = TestClient(v_api.app)
@@ -90,7 +89,7 @@ def test_torch_predict_ptype_batch():
 def test_torch_predict_ptype_error():
 
     x_train, torch_model = _build_torch_v()
-    v = VetiverModel(torch_model, model_name = "torch", save_ptype=True, ptype_data=x_train)
+    v = VetiverModel(torch_model, model_name = "torch", ptype_data=x_train)
     v_api = VetiverAPI(v)
 
     client = TestClient(v_api.app)
@@ -103,7 +102,7 @@ def test_torch_predict_ptype_error():
 def test_torch_predict_no_ptype():
     torch.manual_seed(3)
     x_train, torch_model = _build_torch_v()
-    v = VetiverModel(torch_model, model_name = "torch", save_ptype=False, ptype_data=x_train)
+    v = VetiverModel(torch_model, model_name = "torch", ptype_data=x_train)
     v_api = VetiverAPI(v, check_ptype=False)
 
     client = TestClient(v_api.app)
@@ -116,7 +115,7 @@ def test_torch_predict_no_ptype():
 def test_torch_predict_no_ptype_batch():
     torch.manual_seed(3)
     x_train, torch_model = _build_torch_v()
-    v = VetiverModel(torch_model, model_name = "torch", save_ptype=False, ptype_data=x_train)
+    v = VetiverModel(torch_model, model_name = "torch")
     v_api = VetiverAPI(v, check_ptype=False)
 
     client = TestClient(v_api.app)
@@ -129,7 +128,7 @@ def test_torch_predict_no_ptype_batch():
 def test_torch_predict_no_ptype_error():
 
     x_train, torch_model = _build_torch_v()
-    v = VetiverModel(torch_model, model_name = "torch", save_ptype=False, ptype_data=x_train)
+    v = VetiverModel(torch_model, model_name = "torch")
     v_api = VetiverAPI(v, check_ptype=False)
 
     client = TestClient(v_api.app)

--- a/vetiver/tests/test_sklearn.py
+++ b/vetiver/tests/test_sklearn.py
@@ -6,13 +6,12 @@ from fastapi.testclient import TestClient
 import numpy as np
 
 
-def _start_application(save_ptype: bool):
+def _start_application(save_ptype: bool=True):
     X, y = mock.get_mock_data()
     model = mock.get_mock_model().fit(X, y)
     v = VetiverModel(
         model=model,
-        save_ptype=save_ptype,
-        ptype_data=X,
+        ptype_data=X if save_ptype else None,
         model_name="my_model",
         versioned=None,
         description="A regression model for testing purposes",
@@ -25,7 +24,7 @@ def _start_application(save_ptype: bool):
 
 def test_predict_endpoint_ptype():
     np.random.seed(500)
-    client = TestClient(_start_application(save_ptype=True).app)
+    client = TestClient(_start_application().app)
     data = {"B": 0, "C": 0, "D": 0}
     response = client.post("/predict/", json=data)
     assert response.status_code == 200, response.text
@@ -33,7 +32,7 @@ def test_predict_endpoint_ptype():
 
 def test_predict_endpoint_ptype_batch():
     np.random.seed(500)
-    client = TestClient(_start_application(save_ptype=True).app)
+    client = TestClient(_start_application().app)
     data = [{"B": 0, "C": 0, "D": 0},{"B": 0, "C": 0, "D": 0}]
     response = client.post("/predict/", json=data)
     assert response.status_code == 200, response.text
@@ -42,7 +41,7 @@ def test_predict_endpoint_ptype_batch():
 
 def test_predict_endpoint_ptype_error():
     np.random.seed(500)
-    client = TestClient(_start_application(save_ptype=True).app)
+    client = TestClient(_start_application().app)
     data = {"B": 0, "C": 'a', "D": 0}
     response = client.post("/predict/", json=data)
     assert response.status_code == 422, response.text # value is not a valid integer

--- a/vetiver/vetiver_model.py
+++ b/vetiver/vetiver_model.py
@@ -24,8 +24,6 @@ class VetiverModel:
         A trained model, such as an sklearn or spacy model
     name : string
         Model name or ID
-    save_ptype :  bool
-        Should an input data prototype be saved with the model? 'TRUE' or 'FALSE'
     ptype_data : pd.DataFrame, np.array
         Sample of data model should expect when it is being served
     versioned :
@@ -40,21 +38,15 @@ class VetiverModel:
         self,
         model,
         model_name: str,
-        save_ptype: bool = True,
         ptype_data=None,
         versioned=None,
         description: str = None,
         metadata: dict = None,
         **kwargs
     ):
-        translator = create_translator(model, ptype_data, save_ptype)
-
-        if save_ptype is True:
-            if ptype_data is None:
-                raise AttributeError
+        translator = create_translator(model, ptype_data)
 
         self.model = model
-        self.save_ptype = save_ptype
         self.ptype = translator.ptype()
         self.model_name = model_name
         self.description = description if description else translator.create_description()


### PR DESCRIPTION
This PR has not created a cascading requirement for singledispatch as originally thought. But, it has brought up another issue (unresolved). Previous code could "sneak-peak" at the `ptype_data` when it was available to effectively infer types when the Model had been created with `save_ptype=False`. This is not possible any more and it has broken `TorchHandler.predict` for the case when there is not ptype (`ptype_data=None`).