### PR TITLE
Add macos and windows ci testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,11 +9,12 @@ on:
     types: [published]
 
 jobs:
-  tests:
+  build:
     name: "Tests"
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: ['ubuntu-latest', 'macosx-latest', 'windows-latest']
         python-version: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,13 +9,21 @@ on:
     types: [published]
 
 jobs:
-  build:
+  tests:
     name: "Tests"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'macosx-latest', 'windows-latest']
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        include:
+          - os: 'ubuntu-latest'
+            python-version: '3.7'
+          - os: 'macos-latest'
+            python-version: '3.8'
+          - os: 'windows-latest'
+            python-version: '3.9'
+          - os: 'ubuntu-latest'
+            python-version: '3.10'
+
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2


### PR DESCRIPTION
There are 12 tests, 4 tests per operating system, 1 for each supported version of python. The macosx and windows tests seem to take longer to get going, probably there are limited number of machines.

As this is pure python package it may be overkill, 1 test for each of macos and windows should be enough.