### PR TITLE
feat: initial vetiver_pin_metrics implementation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,8 @@ repos:
         # line too long and line before binary operator (black is ok with these)
         types:
           - python
+        args:
+          - "--max-line-length=90"
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml

--- a/vetiver/tests/test_monitor.py
+++ b/vetiver/tests/test_monitor.py
@@ -6,6 +6,8 @@ import pins
 import numpy
 import vetiver
 
+import pytest
+
 rng = pd.date_range("1/1/2012", periods=10, freq="S")
 new = dict(x=range(len(rng)), y=range(len(rng)))
 df = pd.DataFrame(new, index=rng)
@@ -41,16 +43,21 @@ def test_monitor(snapshot):
     snapshot.assert_match(m.to_json(), "test_monitor.json")
 
 
-def test_vetiver_pin_metrics():
-    board = pins.board_temp()
-    df_metrics_old = pd.DataFrame(
+@pytest.fixture
+def df_metrics_old():
+    return pd.DataFrame(
         {
             "index": pd.to_datetime(["2021-01-01", "2021-01-02"]),
             "n": [1, 2],
             "metric": ["x", "x"],
-            "estimate": [0.6, 0.7],
+            "estimate": [0.1, 0.2],
         }
     )
+
+
+def test_vetiver_pin_metrics_simple(df_metrics_old):
+    board = pins.board_temp()
+    board.pin_write(df_metrics_old, "test_metrics", type="csv")
 
     df_metrics_new = pd.DataFrame(
         {
@@ -61,8 +68,53 @@ def test_vetiver_pin_metrics():
         }
     )
 
-    board.pin_write(df_metrics_old, "test_metrics", type="arrow")
-
     df_res = vetiver.pin_metrics(board, df_metrics_new, "test_metrics")
 
     assert len(df_res) == 4
+    assert df_res.equals(pd.concat([df_metrics_old, df_metrics_new], ignore_index=True))
+
+
+def test_vetiver_pin_metrics_overlap_error(df_metrics_old):
+    board = pins.board_temp()
+    board.pin_write(df_metrics_old, "test_metrics", type="csv")
+
+    with pytest.raises(ValueError) as exc_info:
+        vetiver.pin_metrics(board, df_metrics_old, "test_metrics")
+
+    assert "The new metrics overlap" in exc_info.value.args[0]
+
+
+def test_vetiver_pin_metrics_overwrite(df_metrics_old):
+    board = pins.board_temp()
+    board.pin_write(df_metrics_old, "test_metrics", type="csv")
+
+    # first row should update existing metrics
+    df_metrics_new = pd.DataFrame(
+        {
+            "index": pd.to_datetime(["2021-01-01", "2021-01-03"]),
+            "n": [200, 201],
+            "metric": ["y", "y"],
+            "estimate": [0.8, 0.9],
+        }
+    )
+
+    df_res = vetiver.pin_metrics(board, df_metrics_new, "test_metrics", overwrite=True)
+    assert len(df_res) == 3
+
+    df_dst = pd.concat([df_metrics_old.iloc[[1], :], df_metrics_new], ignore_index=True)
+    assert df_res.equals(df_dst.sort_values("index"))
+
+
+def test_vetiver_pin_metrics_manual_pin_type(df_metrics_old):
+    board = pins.board_temp()
+    board.pin_write(df_metrics_old, "test_metrics", type="csv")
+
+    df_res = vetiver.pin_metrics(
+        board, df_metrics_old, "test_metrics", overwrite=True, pin_type="joblib"
+    )
+
+    assert len(df_res) == 2
+
+    meta = board.pin_meta("test_metrics")
+
+    assert meta.type == "joblib"

--- a/vetiver/tests/test_monitor.py
+++ b/vetiver/tests/test_monitor.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 import pandas as pd
 import pins
 import numpy
+import time
 import vetiver
 
 import pytest
@@ -58,6 +59,7 @@ def df_metrics_old():
 def test_vetiver_pin_metrics_simple(df_metrics_old):
     board = pins.board_temp()
     board.pin_write(df_metrics_old, "test_metrics", type="csv")
+    time.sleep(1)
 
     df_metrics_new = pd.DataFrame(
         {
@@ -77,6 +79,7 @@ def test_vetiver_pin_metrics_simple(df_metrics_old):
 def test_vetiver_pin_metrics_overlap_error(df_metrics_old):
     board = pins.board_temp()
     board.pin_write(df_metrics_old, "test_metrics", type="csv")
+    time.sleep(0.1)
 
     with pytest.raises(ValueError) as exc_info:
         vetiver.pin_metrics(board, df_metrics_old, "test_metrics")
@@ -87,6 +90,7 @@ def test_vetiver_pin_metrics_overlap_error(df_metrics_old):
 def test_vetiver_pin_metrics_overwrite(df_metrics_old):
     board = pins.board_temp()
     board.pin_write(df_metrics_old, "test_metrics", type="csv")
+    time.sleep(1)
 
     # first row should update existing metrics
     df_metrics_new = pd.DataFrame(
@@ -108,6 +112,7 @@ def test_vetiver_pin_metrics_overwrite(df_metrics_old):
 def test_vetiver_pin_metrics_manual_pin_type(df_metrics_old):
     board = pins.board_temp()
     board.pin_write(df_metrics_old, "test_metrics", type="csv")
+    time.sleep(1)
 
     df_res = vetiver.pin_metrics(
         board, df_metrics_old, "test_metrics", overwrite=True, pin_type="joblib"


### PR DESCRIPTION
Quick note on pre-commit:

* I think some of the current hadn't been run through pre-commit, so were tweaked a bit by black.
* I set flake8 to allow lines to be 90 characters so it wouldn't error for somethings black won't format (docstrings etc..). We can remove and re-format them by hand if needed!

TODO:

- [x] : If people save metrics as a CSV, then we need to parse their date index as a datetime. (I set everything to use type="arrow" as a placeholder for now, so tests would pass. But we should change before merging).
- [x] : Need to test different overwrite conditions (e.g. when it should error out, check that it works as expected).