### PR TITLE
explicitly add `n` to hover data in `plot_metrics`

### DIFF
--- a/vetiver/monitor.py
+++ b/vetiver/monitor.py
@@ -157,9 +157,11 @@ def plot_metrics(
         y=estimate,
         color=metric,
         facet_row=metric,
-        markers=n,
+        markers=dict(size=n),
+        hover_data={"n": ':'},
         **kw,
     )
+
     fig.for_each_annotation(lambda a: a.update(text=a.text.split("=")[-1]))
     fig.update_layout(showlegend=False)
 


### PR DESCRIPTION
Force `n` to be shown in hover mode every time graphs are rendered via `plot_metrics` 📈 