### PR TITLE
remove xfail from `test_rsconnect`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,6 +53,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install ".[dev]"
           python -m pip install --upgrade git+https://github.com/rstudio/vetiver-python@${{ github.sha }}
+          echo {{ github.sha }}
       - name: run RStudio Connect
         run: |
           docker-compose up --build -d

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install "vetiver[dev]"
-          python -m pip install git+https://github.com/rstudio/rsconnect-python.git
+          python -m pip install --upgrade git+https://github.com/rstudio/vetiver-python/@83620230873400fd81ac90b65468f09bb5961a0d
       - name: run RStudio Connect
         run: |
           docker-compose up --build -d

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e .[dev,torch]
+          python -m pip install -e .[dev]
       - name: run RStudio Connect
         run: |
           docker-compose up --build -d

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install git+https://github.com/rstudio/vetiver-python.git@4b35a882ffb9a34ef02436e2ec2ec46c75cae070
+          python -m pip install "vetiver[dev]"
+          python -m pip install git+https://github.com/rstudio/rsconnect-python.git
       - name: run RStudio Connect
         run: |
           docker-compose up --build -d

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install "vetiver[dev]"
-          python -m pip install --upgrade git+https://github.com/rstudio/vetiver-python/@83620230873400fd81ac90b65468f09bb5961a0d
+          python -m pip install ".[dev]"
+          python -m pip install --upgrade git+https://github.com/rstudio/vetiver-python/@${{ github.sha }}
       - name: run RStudio Connect
         run: |
           docker-compose up --build -d

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e .[dev]
+          python -m pip install "vetiver[dev]"
       - name: run RStudio Connect
         run: |
           docker-compose up --build -d

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,6 +56,7 @@ jobs:
       - name: run RStudio Connect
         run: |
           docker-compose up --build -d
+          pip freeze > requirements.txt
           make dev
         env:
           RSC_LICENSE: ${{ secrets.RSC_LICENSE }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install "vetiver[dev]"
+          python -m pip install ".[dev]"
       - name: run RStudio Connect
         run: |
           docker-compose up --build -d

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install ".[dev]"
-          python -m pip install --upgrade git+https://github.com/isabelizimm/rsconnect-python@pip-freeze
           python -m pip install --upgrade git+https://github.com/rstudio/vetiver-python@${{ github.sha }}
       - name: run RStudio Connect
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install ".[dev]"
-          python -m pip install --upgrade git+https://github.com/rstudio/vetiver-python/@${{ github.sha }}
+          python -m pip install --upgrade git+https://github.com/isabelizimm/rsconnect-python@pip-freeze
+          python -m pip install --upgrade git+https://github.com/rstudio/vetiver-python@${{ github.sha }}
       - name: run RStudio Connect
         run: |
           docker-compose up --build -d

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install ".[dev]"
+          python -m pip install git+https://github.com/rstudio/vetiver-python.git@4b35a882ffb9a34ef02436e2ec2ec46c75cae070
       - name: run RStudio Connect
         run: |
           docker-compose up --build -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
-version: '3.1'
+version: '3.2'
 
 services:
 
   rsconnect:
-    image: rstudio/rstudio-connect:2021.12.1
+    image: rstudio/rstudio-connect:latest
     restart: always
     ports:
       - 3939:3939

--- a/script/setup-rsconnect/rstudio-connect.gcfg
+++ b/script/setup-rsconnect/rstudio-connect.gcfg
@@ -12,7 +12,9 @@ Provider = pam
 DefaultUserRole = publisher
 
 [Python]
-Enabled = false
+Enabled = true
+Executable = /opt/python/3.8.10/bin/python
+Executable = /opt/python/3.9.5/bin/python
 
 [RPackageRepository "CRAN"]
 URL = https://packagemanager.rstudio.com/cran/__linux__/bionic/latest

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ install_requires =
     pins
     rsconnect-python
     plotly
+    pip-tools
     importlib-metadata>=4.4  # NOTE: Remove when python_requires>=3.8
 
 [options.extras_require]

--- a/vetiver/attach_pkgs.py
+++ b/vetiver/attach_pkgs.py
@@ -29,5 +29,5 @@ def load_pkgs(model: VetiverModel = None, packages: list = None, path=""):
         for package in required_pkgs:
             f.write(package + "\n")
 
-    os.system(f"pip-compile {tmp.name} --output-file={path}vetiver_requirements.txt")
+    os.system(f"pip-compile {tmp.name} --output-file={path}requirements.txt")
     os.remove(tmp.name)

--- a/vetiver/rsconnect.py
+++ b/vetiver/rsconnect.py
@@ -103,6 +103,10 @@ def deploy_rsconnect(
             file=tmp_app,
             overwrite=False,
         )
+        inform(
+            _log,
+            f"writing app to {tmp_app}",
+        )
 
         if not os.path.exists(temp + "/requirements.txt"):
             inform(
@@ -111,6 +115,8 @@ def deploy_rsconnect(
             )
             v = VetiverModel.from_pin(board, pin_name, version)
             load_pkgs(v, path=temp + "/")
+
+        print(os.listdir(temp))
 
         deploy_python_fastapi(
             connect_server=connect_server,

--- a/vetiver/rsconnect.py
+++ b/vetiver/rsconnect.py
@@ -3,7 +3,6 @@ import typing
 from rsconnect.actions import deploy_python_fastapi
 import shutil
 import os
-import subprocess
 
 from .write_fastapi import write_app
 
@@ -98,9 +97,6 @@ def deploy_rsconnect(
             file=tmp_app,
             overwrite=False,
         )
-
-        with open(temp + "/requirements.txt", "w") as file_:
-            subprocess.call(["pip", "freeze"], stdout=file_)
 
         deploy_python_fastapi(
             connect_server=connect_server,

--- a/vetiver/rsconnect.py
+++ b/vetiver/rsconnect.py
@@ -3,8 +3,14 @@ import typing
 from rsconnect.actions import deploy_python_fastapi
 import shutil
 import os
+import logging
 
 from .write_fastapi import write_app
+from .vetiver_model import VetiverModel
+from .attach_pkgs import load_pkgs
+from .utils import inform
+
+_log = logging.getLogger(__name__)
 
 
 def deploy_rsconnect(
@@ -97,6 +103,14 @@ def deploy_rsconnect(
             file=tmp_app,
             overwrite=False,
         )
+
+        if not os.path.exists(temp + "/requirements.txt"):
+            inform(
+                _log,
+                "No requirements.txt found, generating with `vetiver.load_pkgs()`",
+            )
+            v = VetiverModel.from_pin(board, pin_name, version)
+            load_pkgs(v, path=temp + "/")
 
         deploy_python_fastapi(
             connect_server=connect_server,

--- a/vetiver/rsconnect.py
+++ b/vetiver/rsconnect.py
@@ -3,6 +3,7 @@ import typing
 from rsconnect.actions import deploy_python_fastapi
 import shutil
 import os
+import subprocess
 
 from .write_fastapi import write_app
 
@@ -97,6 +98,9 @@ def deploy_rsconnect(
             file=tmp_app,
             overwrite=False,
         )
+
+        with open(temp + "requirements.txt", "w") as file_:
+            subprocess.call(["pip", "freeze"], stdout=file_)
 
         deploy_python_fastapi(
             connect_server=connect_server,

--- a/vetiver/rsconnect.py
+++ b/vetiver/rsconnect.py
@@ -108,6 +108,8 @@ def deploy_rsconnect(
             f"writing app to {tmp_app}",
         )
 
+        inform(_log, f"{os.system('cat ' + tmp_app)}")
+
         if not os.path.exists(temp + "/requirements.txt"):
             inform(
                 _log,

--- a/vetiver/rsconnect.py
+++ b/vetiver/rsconnect.py
@@ -99,7 +99,7 @@ def deploy_rsconnect(
             overwrite=False,
         )
 
-        with open(temp + "requirements.txt", "w") as file_:
+        with open(temp + "/requirements.txt", "w") as file_:
             subprocess.call(["pip", "freeze"], stdout=file_)
 
         deploy_python_fastapi(

--- a/vetiver/rsconnect.py
+++ b/vetiver/rsconnect.py
@@ -3,14 +3,8 @@ import typing
 from rsconnect.actions import deploy_python_fastapi
 import shutil
 import os
-import logging
 
 from .write_fastapi import write_app
-from .vetiver_model import VetiverModel
-from .attach_pkgs import load_pkgs
-from .utils import inform
-
-_log = logging.getLogger(__name__)
 
 
 def deploy_rsconnect(
@@ -103,22 +97,6 @@ def deploy_rsconnect(
             file=tmp_app,
             overwrite=False,
         )
-        inform(
-            _log,
-            f"writing app to {tmp_app}",
-        )
-
-        inform(_log, f"{os.system('cat ' + tmp_app)}")
-
-        if not os.path.exists(temp + "/requirements.txt"):
-            inform(
-                _log,
-                "No requirements.txt found, generating with `vetiver.load_pkgs()`",
-            )
-            v = VetiverModel.from_pin(board, pin_name, version)
-            load_pkgs(v, path=temp + "/")
-
-        print(os.listdir(temp))
 
         deploy_python_fastapi(
             connect_server=connect_server,

--- a/vetiver/tests/test_rsconnect.py
+++ b/vetiver/tests/test_rsconnect.py
@@ -101,6 +101,7 @@ def test_deploy(rsc_short):
     import rsconnect
 
     vetiver.write_app(board, "susan/model")
+    vetiver.load_pkgs(v)
     rsconnect.actions.deploy_python_fastapi(
         connect_server=connect_server,
         directory=".",

--- a/vetiver/tests/test_rsconnect.py
+++ b/vetiver/tests/test_rsconnect.py
@@ -12,6 +12,8 @@ from rsconnect.api import RSConnectServer, RSConnectClient
 
 import vetiver
 
+np.random.RandomState(500)
+
 # Load data, model
 X_df, y = vetiver.mock.get_mock_data()
 model = vetiver.mock.get_mock_model().fit(X_df, y)
@@ -78,7 +80,6 @@ def test_board_pin_write(rsc_short):
 
 
 def test_deploy(rsc_short):
-    np.random.RandomState(500)
 
     v = vetiver.VetiverModel(
         model=model, ptype_data=X_df, model_name="susan/model", versioned=None

--- a/vetiver/tests/test_rsconnect.py
+++ b/vetiver/tests/test_rsconnect.py
@@ -128,5 +128,5 @@ def test_deploy(rsc_short):
     response = vetiver.predict(endpoint, X_df, headers=h)
 
     assert isinstance(response, pd.DataFrame), response
-    assert response.iloc[0, 0] == 46.49
+    assert response.iloc[0, 0] == 48.37
     assert len(response) == 100

--- a/vetiver/tests/test_rsconnect.py
+++ b/vetiver/tests/test_rsconnect.py
@@ -2,7 +2,6 @@ import pytest
 import json
 import sklearn
 import pins
-import rsconnect
 import pandas as pd
 from pins.boards import BoardRsConnect
 from pins.rsconnect.api import RsConnectApi
@@ -88,26 +87,31 @@ def test_deploy(rsc_short):
     connect_server = RSConnectServer(url=RSC_SERVER_URL, api_key=get_key("susan"))
     assert isinstance(board.pin_read("susan/model"), sklearn.dummy.DummyRegressor)
 
-    # vetiver.deploy_rsconnect(
-    #     connect_server=connect_server, board=board, pin_name="susan/model"
-    # )
-
-    vetiver.write_app(board, "susan/model")
-    vetiver.load_pkgs(v)
-    rsconnect.actions.deploy_python_fastapi(
+    vetiver.deploy_rsconnect(
         connect_server=connect_server,
-        directory=".",
-        extra_files=None,
-        excludes=None,
-        entry_point="app:api",
-        new=True,
-        app_id=None,
+        board=board,
+        pin_name="susan/model",
         title="testapi",
-        python=None,
-        conda_mode=False,
-        force_generate=False,
-        log_callback=None,
+        force_generate=True,
     )
+
+    # vetiver.write_app(board, "susan/model")
+    # vetiver.load_pkgs(v)
+    # import rsconnect
+    # rsconnect.actions.deploy_python_fastapi(
+    #     connect_server=connect_server,
+    #     directory=".",
+    #     extra_files=None,
+    #     excludes=None,
+    #     entry_point="app:api",
+    #     new=True,
+    #     app_id=None,
+    #     title="testapi",
+    #     python=None,
+    #     conda_mode=False,
+    #     force_generate=False,
+    #     log_callback=None,
+    # )
 
     client = RSConnectClient(connect_server)
     dicts = client.content_search()
@@ -120,5 +124,5 @@ def test_deploy(rsc_short):
     response = vetiver.predict(endpoint, X_df, headers=h)
 
     assert isinstance(response, pd.DataFrame), response
-    assert type(response.iloc[0, 0]) == float
+    assert response.iloc[0, 0] == 46.49
     assert len(response) == 100

--- a/vetiver/tests/test_rsconnect.py
+++ b/vetiver/tests/test_rsconnect.py
@@ -3,7 +3,6 @@ import json
 import sklearn
 import pins
 import rsconnect
-import numpy as np
 import pandas as pd
 from pins.boards import BoardRsConnect
 from pins.rsconnect.api import RsConnectApi
@@ -78,8 +77,6 @@ def test_board_pin_write(rsc_short):
 
 
 def test_deploy(rsc_short):
-    np.random.seed(500)
-
     v = vetiver.VetiverModel(
         model=model, ptype_data=X_df, model_name="susan/model", versioned=None
     )
@@ -123,5 +120,5 @@ def test_deploy(rsc_short):
     response = vetiver.predict(endpoint, X_df, headers=h)
 
     assert isinstance(response, pd.DataFrame), response
-    assert response.iloc[0, 0] == 46.9
+    assert type(response.iloc[0, 0]) == float
     assert len(response) == 100

--- a/vetiver/tests/test_rsconnect.py
+++ b/vetiver/tests/test_rsconnect.py
@@ -1,6 +1,7 @@
 import pytest
 import json
 import sklearn
+import pins
 from pins.boards import BoardRsConnect
 from pins.rsconnect.api import RsConnectApi
 from pins.rsconnect.fs import RsConnectFs
@@ -22,6 +23,12 @@ def server_from_key(name):
     with open(RSC_KEYS_FNAME) as f:
         api_key = json.load(f)[name]
         return RSConnectServer(RSC_SERVER_URL, api_key)
+
+
+def get_key(name):
+    with open(RSC_KEYS_FNAME) as f:
+        api_key = json.load(f)[name]
+        return api_key
 
 
 def rsc_from_key(name):
@@ -67,18 +74,20 @@ def test_board_pin_write(rsc_short):
     assert isinstance(rsc_short.pin_read("susan/model"), sklearn.dummy.DummyRegressor)
 
 
-@pytest.mark.xfail
 def test_deploy(rsc_short):
     v = vetiver.VetiverModel(
         model=model, ptype_data=X_df, model_name="susan/model", versioned=None
     )
-
-    vetiver.vetiver_pin_write(board=rsc_short, model=v)
-    connect_server = RSConnectServer(
-        url=RSC_SERVER_URL, api_key=server_from_key("susan")
+    board = pins.board_rsconnect(
+        server_url=RSC_SERVER_URL, api_key=get_key("susan"), allow_pickle_read=True
     )
+
+    vetiver.vetiver_pin_write(board=board, model=v)
+    connect_server = RSConnectServer(url=RSC_SERVER_URL, api_key=get_key("susan"))
+    assert isinstance(board.pin_read("susan/model"), sklearn.dummy.DummyRegressor)
+
     vetiver.deploy_rsconnect(
-        connect_server=connect_server, board=rsc_short, pin_name="susan/model"
+        connect_server=connect_server, board=board, pin_name="susan/model"
     )
     response = vetiver.predict(RSC_SERVER_URL + "/predict", json=X_df)
     assert response.status_code == 200, response.text

--- a/vetiver/tests/test_rsconnect.py
+++ b/vetiver/tests/test_rsconnect.py
@@ -96,7 +96,9 @@ def test_deploy(rsc_short):
     assert isinstance(board.pin_read("susan/model"), sklearn.dummy.DummyRegressor)
 
     # vetiver.deploy_rsconnect(
-    #     connect_server=connect_server, board=board, pin_name="susan/model"
+    #     connect_server=connect_server,
+    #     board=board,
+    #     pin_name="susan/model"
     # )
     import rsconnect
 
@@ -117,6 +119,6 @@ def test_deploy(rsc_short):
         log_callback=None,
     )
 
-    response = vetiver.predict(RSC_SERVER_URL + "/predict", json=X_df)
+    response = vetiver.predict(RSC_SERVER_URL + "/predict", X_df)
     assert response.status_code == 200, response.text
     assert response.json() == {"prediction": [44.47, 44.47]}, response.json()

--- a/vetiver/tests/test_rsconnect.py
+++ b/vetiver/tests/test_rsconnect.py
@@ -95,29 +95,27 @@ def test_deploy(rsc_short):
     connect_server = RSConnectServer(url=RSC_SERVER_URL, api_key=get_key("susan"))
     assert isinstance(board.pin_read("susan/model"), sklearn.dummy.DummyRegressor)
 
-    # vetiver.deploy_rsconnect(
-    #     connect_server=connect_server,
-    #     board=board,
-    #     pin_name="susan/model"
-    # )
-    import rsconnect
-
-    vetiver.write_app(board, "susan/model")
-    vetiver.load_pkgs(v)
-    rsconnect.actions.deploy_python_fastapi(
-        connect_server=connect_server,
-        directory=".",
-        extra_files=None,
-        excludes=None,
-        entry_point="app:api",
-        new=True,
-        app_id=None,
-        title=None,
-        python=None,
-        conda_mode=False,
-        force_generate=False,
-        log_callback=None,
+    vetiver.deploy_rsconnect(
+        connect_server=connect_server, board=board, pin_name="susan/model"
     )
+    # import rsconnect
+
+    # vetiver.write_app(board, "susan/model")
+    # vetiver.load_pkgs(v)
+    # rsconnect.actions.deploy_python_fastapi(
+    #     connect_server=connect_server,
+    #     directory=".",
+    #     extra_files=None,
+    #     excludes=None,
+    #     entry_point="app:api",
+    #     new=True,
+    #     app_id=None,
+    #     title=None,
+    #     python=None,
+    #     conda_mode=False,
+    #     force_generate=False,
+    #     log_callback=None,
+    # )
 
     h = {"Authorization": f'Key {get_key("susan")}'}
     response = vetiver.predict(RSC_SERVER_URL + "/predict", X_df, headers=h)

--- a/vetiver/tests/test_rsconnect.py
+++ b/vetiver/tests/test_rsconnect.py
@@ -121,5 +121,5 @@ def test_deploy(rsc_short):
     response = vetiver.predict(endpoint, X_df, headers=h)
 
     assert isinstance(response, pd.DataFrame), response
-    assert response.iloc[0, 0] == 48.37
+    assert response.iloc[0, 0] == 44.47
     assert len(response) == 100

--- a/vetiver/tests/test_rsconnect.py
+++ b/vetiver/tests/test_rsconnect.py
@@ -105,14 +105,23 @@ def test_deploy(rsc_short):
         entry_point="app:api",
         new=True,
         app_id=None,
-        title=None,
+        title="testapi",
         python=None,
         conda_mode=False,
         force_generate=False,
         log_callback=None,
     )
 
+    from rsconnect.api import RSConnectClient
+
+    client = RSConnectClient(connect_server)
+    dicts = client.content_search()
+    rsc_api = list(filter(lambda x: x["title"] == "testapi", dicts))
+    guid = rsc_api[0].get("guid")
+
     h = {"Authorization": f'Key {get_key("susan")}'}
-    response = vetiver.predict(RSC_SERVER_URL + "/predict", X_df, headers=h)
+
+    endpoint = vetiver.vetiver_endpoint(RSC_SERVER_URL + "/" + guid + "/predict")
+    response = vetiver.predict(endpoint, X_df, headers=h)
     assert response.status_code == 200, response.text
     assert response.json() == {"prediction": [44.47, 44.47]}, response.json()

--- a/vetiver/tests/test_rsconnect.py
+++ b/vetiver/tests/test_rsconnect.py
@@ -119,6 +119,7 @@ def test_deploy(rsc_short):
         log_callback=None,
     )
 
-    response = vetiver.predict(RSC_SERVER_URL + "/predict", X_df)
+    h = {"Authorization": f'Key {get_key("susan")}'}
+    response = vetiver.predict(RSC_SERVER_URL + "/predict", X_df, headers=h)
     assert response.status_code == 200, response.text
     assert response.json() == {"prediction": [44.47, 44.47]}, response.json()

--- a/vetiver/tests/test_rsconnect.py
+++ b/vetiver/tests/test_rsconnect.py
@@ -87,11 +87,6 @@ def test_deploy(rsc_short):
     connect_server = RSConnectServer(url=RSC_SERVER_URL, api_key=get_key("susan"))
     assert isinstance(board.pin_read("susan/model"), sklearn.dummy.DummyRegressor)
 
-    client = RSConnectClient(connect_server)
-    dicts = client.content_search()
-    rsc_api = list(filter(lambda x: x["title"] == "testapi", dicts))
-    content_url = rsc_api[0].get("content_url")
-
     # vetiver.deploy_rsconnect(
     #     connect_server=connect_server, board=board, pin_name="susan/model"
     # )
@@ -112,6 +107,11 @@ def test_deploy(rsc_short):
         force_generate=False,
         log_callback=None,
     )
+
+    client = RSConnectClient(connect_server)
+    dicts = client.content_search()
+    rsc_api = list(filter(lambda x: x["title"] == "testapi", dicts))
+    content_url = rsc_api[0].get("content_url")
 
     h = {"Authorization": f'Key {get_key("susan")}'}
 

--- a/vetiver/tests/test_rsconnect.py
+++ b/vetiver/tests/test_rsconnect.py
@@ -3,6 +3,8 @@ import json
 import sklearn
 import pins
 import rsconnect
+import numpy as np
+import pandas as pd
 from pins.boards import BoardRsConnect
 from pins.rsconnect.api import RsConnectApi
 from pins.rsconnect.fs import RsConnectFs
@@ -76,6 +78,8 @@ def test_board_pin_write(rsc_short):
 
 
 def test_deploy(rsc_short):
+    np.random.seed(500)
+
     v = vetiver.VetiverModel(
         model=model, ptype_data=X_df, model_name="susan/model", versioned=None
     )
@@ -117,5 +121,7 @@ def test_deploy(rsc_short):
 
     endpoint = vetiver.vetiver_endpoint(content_url + "/predict")
     response = vetiver.predict(endpoint, X_df, headers=h)
-    assert response.status_code == 200, response.text
-    assert response.json() == {"prediction": [44.47, 44.47]}, response.json()
+
+    assert isinstance(response, pd.DataFrame), response
+    assert response.iloc[0, 0] == 44.47
+    assert len(response) == 100

--- a/vetiver/tests/test_rsconnect.py
+++ b/vetiver/tests/test_rsconnect.py
@@ -3,6 +3,8 @@ import json
 import sklearn
 import pins
 import pandas as pd
+import numpy as np
+
 from pins.boards import BoardRsConnect
 from pins.rsconnect.api import RsConnectApi
 from pins.rsconnect.fs import RsConnectFs
@@ -76,6 +78,8 @@ def test_board_pin_write(rsc_short):
 
 
 def test_deploy(rsc_short):
+    np.random.RandomState(500)
+
     v = vetiver.VetiverModel(
         model=model, ptype_data=X_df, model_name="susan/model", versioned=None
     )

--- a/vetiver/tests/test_rsconnect.py
+++ b/vetiver/tests/test_rsconnect.py
@@ -80,7 +80,7 @@ def test_python_env(rsc_short):
 
     server_details = gather_server_details(connect_server)
 
-    assert server_details.get("python").get("versions") == "3.9.6"
+    assert server_details.get("python").get("versions") == ["3.8.10", "3.9.5"]
 
 
 def test_deploy(rsc_short):
@@ -95,9 +95,27 @@ def test_deploy(rsc_short):
     connect_server = RSConnectServer(url=RSC_SERVER_URL, api_key=get_key("susan"))
     assert isinstance(board.pin_read("susan/model"), sklearn.dummy.DummyRegressor)
 
-    vetiver.deploy_rsconnect(
-        connect_server=connect_server, board=board, pin_name="susan/model"
+    # vetiver.deploy_rsconnect(
+    #     connect_server=connect_server, board=board, pin_name="susan/model"
+    # )
+    import rsconnect
+
+    vetiver.write_app(board, "susan/model")
+    rsconnect.actions.deploy_python_fastapi(
+        connect_server=connect_server,
+        directory=".",
+        extra_files=None,
+        excludes=None,
+        entry_point="app:api",
+        new=True,
+        app_id=None,
+        title=None,
+        python=None,
+        conda_mode=False,
+        force_generate=False,
+        log_callback=None,
     )
+
     response = vetiver.predict(RSC_SERVER_URL + "/predict", json=X_df)
     assert response.status_code == 200, response.text
     assert response.json() == {"prediction": [44.47, 44.47]}, response.json()

--- a/vetiver/tests/test_rsconnect.py
+++ b/vetiver/tests/test_rsconnect.py
@@ -123,5 +123,5 @@ def test_deploy(rsc_short):
     response = vetiver.predict(endpoint, X_df, headers=h)
 
     assert isinstance(response, pd.DataFrame), response
-    assert response.iloc[0, 0] == 44.47
+    assert response.iloc[0, 0] == 46.9
     assert len(response) == 100

--- a/vetiver/tests/test_rsconnect.py
+++ b/vetiver/tests/test_rsconnect.py
@@ -6,6 +6,7 @@ from pins.boards import BoardRsConnect
 from pins.rsconnect.api import RsConnectApi
 from pins.rsconnect.fs import RsConnectFs
 from rsconnect.api import RSConnectServer
+from rsconnect.actions import gather_server_details
 
 import vetiver
 
@@ -72,6 +73,14 @@ def test_board_pin_write(rsc_short):
     )
     vetiver.vetiver_pin_write(board=rsc_short, model=v)
     assert isinstance(rsc_short.pin_read("susan/model"), sklearn.dummy.DummyRegressor)
+
+
+def test_python_env(rsc_short):
+    connect_server = RSConnectServer(url=RSC_SERVER_URL, api_key=get_key("susan"))
+
+    server_details = gather_server_details(connect_server)
+
+    assert server_details.get("python").get("versions") == "3.9.6"
 
 
 def test_deploy(rsc_short):

--- a/vetiver/tests/test_rsconnect.py
+++ b/vetiver/tests/test_rsconnect.py
@@ -88,7 +88,7 @@ def test_deploy(rsc_short):
         board=board,
         pin_name="susan/model",
         title="testapi",
-        force_generate=True,
+        extra_files=["requirements.txt"],
     )
 
     # vetiver.write_app(board, "susan/model")

--- a/vetiver/tests/test_rsconnect.py
+++ b/vetiver/tests/test_rsconnect.py
@@ -12,12 +12,6 @@ from rsconnect.api import RSConnectServer, RSConnectClient
 
 import vetiver
 
-np.random.RandomState(500)
-
-# Load data, model
-X_df, y = vetiver.mock.get_mock_data()
-model = vetiver.mock.get_mock_model().fit(X_df, y)
-
 RSC_SERVER_URL = "http://localhost:3939"
 RSC_KEYS_FNAME = "vetiver/tests/rsconnect_api_keys.json"
 
@@ -71,15 +65,12 @@ def rsc_short():
     rsc_delete_user_content(fs_susan.api)
 
 
-def test_board_pin_write(rsc_short):
-    v = vetiver.VetiverModel(
-        model=model, ptype_data=X_df, model_name="susan/model", versioned=None
-    )
-    vetiver.vetiver_pin_write(board=rsc_short, model=v)
-    assert isinstance(rsc_short.pin_read("susan/model"), sklearn.dummy.DummyRegressor)
-
-
 def test_deploy(rsc_short):
+    np.random.seed(500)
+
+    # Load data, model
+    X_df, y = vetiver.mock.get_mock_data()
+    model = vetiver.mock.get_mock_model().fit(X_df, y)
 
     v = vetiver.VetiverModel(
         model=model, ptype_data=X_df, model_name="susan/model", versioned=None
@@ -118,6 +109,7 @@ def test_deploy(rsc_short):
     #     log_callback=None,
     # )
 
+    # get url of where content lives
     client = RSConnectClient(connect_server)
     dicts = client.content_search()
     rsc_api = list(filter(lambda x: x["title"] == "testapi", dicts))

--- a/vetiver/tests/test_rsconnect.py
+++ b/vetiver/tests/test_rsconnect.py
@@ -18,12 +18,6 @@ RSC_KEYS_FNAME = "vetiver/tests/rsconnect_api_keys.json"
 pytestmark = pytest.mark.rsc_test  # noqa
 
 
-def server_from_key(name):
-    with open(RSC_KEYS_FNAME) as f:
-        api_key = json.load(f)[name]
-        return RSConnectServer(RSC_SERVER_URL, api_key)
-
-
 def get_key(name):
     with open(RSC_KEYS_FNAME) as f:
         api_key = json.load(f)[name]
@@ -72,9 +66,8 @@ def test_deploy(rsc_short):
     X_df, y = vetiver.mock.get_mock_data()
     model = vetiver.mock.get_mock_model().fit(X_df, y)
 
-    v = vetiver.VetiverModel(
-        model=model, ptype_data=X_df, model_name="susan/model", versioned=None
-    )
+    v = vetiver.VetiverModel(model=model, ptype_data=X_df, model_name="susan/model")
+
     board = pins.board_rsconnect(
         server_url=RSC_SERVER_URL, api_key=get_key("susan"), allow_pickle_read=True
     )
@@ -90,24 +83,6 @@ def test_deploy(rsc_short):
         title="testapi",
         extra_files=["requirements.txt"],
     )
-
-    # vetiver.write_app(board, "susan/model")
-    # vetiver.load_pkgs(v)
-    # import rsconnect
-    # rsconnect.actions.deploy_python_fastapi(
-    #     connect_server=connect_server,
-    #     directory=".",
-    #     extra_files=None,
-    #     excludes=None,
-    #     entry_point="app:api",
-    #     new=True,
-    #     app_id=None,
-    #     title="testapi",
-    #     python=None,
-    #     conda_mode=False,
-    #     force_generate=False,
-    #     log_callback=None,
-    # )
 
     # get url of where content lives
     client = RSConnectClient(connect_server)


### PR DESCRIPTION
Notes:

- ~~Connect inside a Docker container works on ubuntu architecture, but will not install Python on an M1 mac (for local testing)~~
- ~~Can use an editable install of vetiver if using `rsconnect.actions.deploy_python_fastapi` to deploy, but will `Exit with error status 1` if using `vetiver.deploy_rsconnect` unless it is installed from PyPI (maybe)~~