### PR TITLE
missing whitespace in InvalidModelError

### DIFF
--- a/vetiver/handlers/base.py
+++ b/vetiver/handlers/base.py
@@ -48,7 +48,7 @@ def create_handler(model, ptype_data):
 
     raise InvalidModelError(
         "Model must be a supported model type, or a "
-        "custom handler must be used. See the docs for more info on custom handlers and"
+        "custom handler must be used. See the docs for more info on custom handlers and "
         "supported types https://rstudio.github.io/vetiver-python/"
     )
 


### PR DESCRIPTION
There is a missing whitespace in the error message

<img width="1164" alt="Screenshot 2022-10-23 at 15 06 26" src="https://user-images.githubusercontent.com/104839700/197393881-75a7ce2e-5be5-4b5c-a715-9bb79db7505f.png">
