### PR TITLE
DOC: Added missing `model_name` to `VetiverModel`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ from vetiver import mock, VetiverModel
 X, y = mock.get_mock_data()
 model = mock.get_mock_model().fit(X, y)
 
-v = VetiverModel(model, save_ptype=True, ptype_data=X)
+v = VetiverModel(model, save_ptype=True, ptype_data=X, model_name='mock_model')
 ```
 
 You can **version** and **share** your `VetiverModel()` by choosing a [pins](https://rstudio.github.io/pins-python/) "board" for it, including a local folder, RStudio Connect, Amazon S3, and more.


### PR DESCRIPTION
### Changes
- Added missing `model_name` to `VetiverModel` in README

As per https://github.com/rstudio/vetiver-python/blob/a70a822d062992530b29a9966776f5b2a30d62fb/vetiver/vetiver_model.py#L65 `model_name` is not optional, hence example for failing.
```py
Traceback (most recent call last):   
  File "/home/ganesh/os/mlops/vetiver-python/hostt.py", line 8, in <module>
    v = VetiverModel(model, save_ptype=True, ptype_data=X)                                                                                                                                                                            
TypeError: VetiverModel.__init__() missing 1 required positional argument: 'model_name'
```