### PR TITLE
BUG, MAINT: Catch non 200 codes 

### DIFF
--- a/vetiver/server.py
+++ b/vetiver/server.py
@@ -258,14 +258,12 @@ def predict(endpoint, data: Union[dict, pd.DataFrame, pd.Series], **kw):
     else:
         response = requester.post(endpoint, json=data, **kw)
 
-    response_json = response.json()
-
     try:
         response.raise_for_status()
     except (requests.exceptions.HTTPError, httpx.HTTPStatusError) as e:
         if response.status_code == 422:
             raise TypeError(
-                f"Predict expects a DataFrame or dict. Given type is {type(data)}"
+                f"Predict expects DataFrame, Series, or dict. Given type is {type(data)}"
             )
         raise requests.exceptions.HTTPError(
             f"Could not obtain data from endpoint with error: {e}"

--- a/vetiver/server.py
+++ b/vetiver/server.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.openapi.utils import get_openapi
 from fastapi import testclient
+import httpx
 
 import uvicorn
 import requests
@@ -240,7 +241,7 @@ def predict(endpoint, data: Union[dict, pd.DataFrame, pd.Series], **kw):
     """
     if isinstance(endpoint, testclient.TestClient):
         requester = endpoint
-        endpoint = "/predict"
+        endpoint = requester.app.root_path
     else:
         requester = requests
 
@@ -255,20 +256,22 @@ def predict(endpoint, data: Union[dict, pd.DataFrame, pd.Series], **kw):
     elif isinstance(data, dict):
         response = requester.post(endpoint, json=data, **kw)
     else:
-        try:
-            response = requester.post(endpoint, json=data, **kw)
-        except TypeError:
+        response = requester.post(endpoint, json=data, **kw)
+
+    response_json = response.json()
+
+    try:
+        response.raise_for_status()
+    except (requests.exceptions.HTTPError, httpx.HTTPStatusError) as e:
+        if response.status_code == 422:
             raise TypeError(
                 f"Predict expects a DataFrame or dict. Given type is {type(data)}"
             )
+        raise requests.exceptions.HTTPError(
+            f"Could not obtain data from endpoint with error: {e}"
+        )
 
     response_df = pd.DataFrame.from_dict(response.json())
-
-    if isinstance(response_df.iloc[0, 0], dict):
-        if "type_error.dict" in response_df.iloc[0, 0].values():
-            raise TypeError(
-                f"Predict expects a DataFrame or dict. Given type is {type(data)}"
-            )
 
     return response_df
 

--- a/vetiver/tests/test_predict.py
+++ b/vetiver/tests/test_predict.py
@@ -24,18 +24,20 @@ def vetiver_model():
 
     return v
 
+
 @pytest.fixture
 def vetiver_client(vetiver_model):  # With check_ptype=True
     app = VetiverAPI(vetiver_model, check_ptype=True)
-    app.app.root_path = '/predict'
+    app.app.root_path = "/predict"
     client = TestClient(app.app)
 
     return client
 
+
 @pytest.fixture
-def vetiver_client_check_ptype_false(vetiver_model):  # With check_ptype=True
+def vetiver_client_check_ptype_false(vetiver_model):  # With check_ptype=False
     app = VetiverAPI(vetiver_model, check_ptype=False)
-    app.app.root_path = '/predict'
+    app.app.root_path = "/predict"
     client = TestClient(app.app)
 
     return client
@@ -77,19 +79,20 @@ def test_predict_sklearn_series_check_ptype(vetiver_client):
     assert response.iloc[0, 0] == 44.47
     assert len(response) == 1
 
-@pytest.mark.parametrize(
-    'data', [(0,0), 0, 0., '0'])
+
+@pytest.mark.parametrize("data", [(0, 0), 0, 0.0, "0"])
 def test_predict_sklearn_type_error(data, vetiver_client):
-    msg = f"Predict expects a DataFrame or dict. Given type is {type(data)}"
+    msg = f"Predict expects DataFrame, Series, or dict. Given type is {type(data)}"
 
     with pytest.raises(TypeError, match=msg):
         predict(endpoint=vetiver_client, data=data)
 
+
 def test_predict_server_error(vetiver_model):
     X, y = mock.get_mock_data()
     app = VetiverAPI(vetiver_model, check_ptype=True)
-    app.app.root_path = '/i_do_not_exists'
+    app.app.root_path = "/i_do_not_exists"
     client = TestClient(app.app)
 
     with pytest.raises(HTTPError):
-        res = predict(endpoint=client, data=X)
+        predict(endpoint=client, data=X)

--- a/vetiver/tests/test_predict.py
+++ b/vetiver/tests/test_predict.py
@@ -9,7 +9,8 @@ from vetiver import mock, VetiverModel, VetiverAPI
 from vetiver.server import predict
 
 
-def test_predict_sklearn_dict_ptype():
+@pytest.fixture
+def vetiver_model():
     np.random.seed(500)
     X, y = mock.get_mock_data()
     model = mock.get_mock_model().fit(X, y)
@@ -20,79 +21,57 @@ def test_predict_sklearn_dict_ptype():
         versioned=None,
         description="A regression model for testing purposes",
     )
-    app = VetiverAPI(v, check_ptype=True)
+
+    return v
+
+@pytest.fixture
+def vetiver_client(vetiver_model):  # With check_ptype=True
+    app = VetiverAPI(vetiver_model, check_ptype=True)
     app.app.root_path = '/predict'
     client = TestClient(app.app)
+
+    return client
+
+@pytest.fixture
+def vetiver_client_check_ptype_false(vetiver_model):  # With check_ptype=True
+    app = VetiverAPI(vetiver_model, check_ptype=False)
+    app.app.root_path = '/predict'
+    client = TestClient(app.app)
+
+    return client
+
+
+def test_predict_sklearn_dict_ptype(vetiver_client):
     data = {"B": 0, "C": 0, "D": 0}
 
-    response = predict(endpoint=client, data=data)
+    response = predict(endpoint=vetiver_client, data=data)
 
     assert isinstance(response, pd.DataFrame), response
     assert response.iloc[0, 0] == 44.47
     assert len(response) == 1
 
 
-def test_predict_sklearn_no_ptype():
-    np.random.seed(500)
+def test_predict_sklearn_no_ptype(vetiver_client_check_ptype_false):
     X, y = mock.get_mock_data()
-    model = mock.get_mock_model().fit(X, y)
-    v = VetiverModel(
-        model=model,
-        ptype_data=X,
-        model_name="my_model",
-        versioned=None,
-        description="A regression model for testing purposes",
-    )
-    app = VetiverAPI(v, check_ptype=False)
-    app.app.root_path = '/predict'
-    client = TestClient(app.app)
-
-    response = predict(endpoint=client, data=X)
+    response = predict(endpoint=vetiver_client_check_ptype_false, data=X)
 
     assert isinstance(response, pd.DataFrame), response
     assert response.iloc[0, 0] == 44.47
     assert len(response) == 100
 
 
-def test_predict_sklearn_df_check_ptype():
-    np.random.seed(500)
+def test_predict_sklearn_df_check_ptype(vetiver_client):
     X, y = mock.get_mock_data()
-    model = mock.get_mock_model().fit(X, y)
-    v = VetiverModel(
-        model=model,
-        ptype_data=X,
-        model_name="my_model",
-        versioned=None,
-        description="A regression model for testing purposes",
-    )
-    app = VetiverAPI(v, check_ptype=True)
-    app.app.root_path = '/predict'
-    client = TestClient(app.app)
-
-    response = predict(endpoint=client, data=X)
+    response = predict(endpoint=vetiver_client, data=X)
 
     assert isinstance(response, pd.DataFrame), response
     assert response.iloc[0, 0] == 44.47
     assert len(response) == 100
 
 
-def test_predict_sklearn_series_check_ptype():
-    np.random.seed(500)
-    X, y = mock.get_mock_data()
+def test_predict_sklearn_series_check_ptype(vetiver_client):
     ser = pd.Series(data=[0, 0, 0])
-    model = mock.get_mock_model().fit(X, y)
-    v = VetiverModel(
-        model=model,
-        ptype_data=X,
-        model_name="my_model",
-        versioned=None,
-        description="A regression model for testing purposes",
-    )
-    app = VetiverAPI(v, check_ptype=True)
-    app.app.root_path = '/predict'
-    client = TestClient(app.app)
-
-    response = predict(endpoint=client, data=ser)
+    response = predict(endpoint=vetiver_client, data=ser)
 
     assert isinstance(response, pd.DataFrame), response
     assert response.iloc[0, 0] == 44.47
@@ -100,37 +79,15 @@ def test_predict_sklearn_series_check_ptype():
 
 @pytest.mark.parametrize(
     'data', [(0,0), 0, 0., '0'])
-def test_predict_sklearn_type_error(data):
-    np.random.seed(500)
-    X, y = mock.get_mock_data()
-    model = mock.get_mock_model().fit(X, y)
-    v = VetiverModel(
-        model=model,
-        ptype_data=X,
-        model_name="my_model",
-        versioned=None,
-        description="A regression model for testing purposes",
-    )
-    app = VetiverAPI(v, check_ptype=True)
-    app.app.root_path = '/predict'
-    client = TestClient(app.app)
+def test_predict_sklearn_type_error(data, vetiver_client):
     msg = f"Predict expects a DataFrame or dict. Given type is {type(data)}"
 
     with pytest.raises(TypeError, match=msg):
-        predict(endpoint=client, data=data)
+        predict(endpoint=vetiver_client, data=data)
 
-def test_predict_server_error():
-    np.random.seed(500)
+def test_predict_server_error(vetiver_model):
     X, y = mock.get_mock_data()
-    model = mock.get_mock_model().fit(X, y)
-    v = VetiverModel(
-        model=model,
-        ptype_data=X,
-        model_name="my_model",
-        versioned=None,
-        description="A regression model for testing purposes",
-    )
-    app = VetiverAPI(v, check_ptype=True)
+    app = VetiverAPI(vetiver_model, check_ptype=True)
     app.app.root_path = '/i_do_not_exists'
     client = TestClient(app.app)
 

--- a/vetiver/tests/test_statsmodels.py
+++ b/vetiver/tests/test_statsmodels.py
@@ -14,7 +14,7 @@ import vetiver  # noqa
 
 
 @pytest.fixture
-def build_sm():
+def sm_model():
 
     X, y = vetiver.get_mock_data()
     glm = sm.GLM(y, X).fit()
@@ -23,43 +23,55 @@ def build_sm():
     return v
 
 
-def test_vetiver_build(build_sm):
-    api = vetiver.VetiverAPI(build_sm)
-    client = TestClient(api.app)
+@pytest.fixture
+def vetiver_client(sm_model):  # With check_ptype=True
+    app = vetiver.VetiverAPI(sm_model, check_ptype=True)
+    app.app.root_path = "/predict"
+    client = TestClient(app.app)
+
+    return client
+
+
+@pytest.fixture
+def vetiver_client_check_ptype_false(sm_model):  # With check_ptype=True
+    app = vetiver.VetiverAPI(sm_model, check_ptype=False)
+    app.app.root_path = "/predict"
+    client = TestClient(app.app)
+
+    return client
+
+
+def test_vetiver_build(vetiver_client):
     data = [{"B": 0, "C": 0, "D": 0}]
 
-    response = vetiver.predict(endpoint=client, data=data)
+    response = vetiver.predict(endpoint=vetiver_client, data=data)
 
     assert response.iloc[0, 0] == 0.0
     assert len(response) == 1
 
 
-def test_batch(build_sm):
-    api = vetiver.VetiverAPI(build_sm)
-    client = TestClient(api.app)
+def test_batch(vetiver_client):
     data = pd.DataFrame(np.random.randint(0, 100, size=(100, 4)), columns=list("ABCD"))
 
-    response = vetiver.predict(endpoint=client, data=data)
+    response = vetiver.predict(endpoint=vetiver_client, data=data)
 
     assert len(response) == 100
 
 
-def test_no_ptype(build_sm):
-    api = vetiver.VetiverAPI(build_sm, check_ptype=False)
-    client = TestClient(api.app)
+def test_no_ptype(vetiver_client_check_ptype_false):
     data = [0, 0, 0]
 
-    response = vetiver.predict(endpoint=client, data=data)
+    response = vetiver.predict(endpoint=vetiver_client_check_ptype_false, data=data)
 
     assert response.iloc[0, 0] == 0.0
     assert len(response) == 1
 
 
-def test_serialize(build_sm):
+def test_serialize(sm_model):
     import pins
 
     board = pins.board_temp(allow_pickle_read=True)
-    vetiver.vetiver_pin_write(board=board, model=build_sm)
+    vetiver.vetiver_pin_write(board=board, model=sm_model)
     assert isinstance(
         board.pin_read("glm"),
         statsmodels.genmod.generalized_linear_model.GLMResultsWrapper,


### PR DESCRIPTION
### Changes
Honestly one thing lead to another and here is what I ended up doing:
1. Fix the actual problem, i.e., catch non-200 responses and handle them:
  1.1. In the case of a 422, raise a `TypeError` (same as before), but without all the extra processing. Now I'm pretty sure (take this with a pinch of salt :)) the status code check is sufficient, we need not check the json for type error
  1.2. In case of every other error, raise an `HTTPError` with a meaningful error message
2. Add test cases for the new `if` and some more test cases for the `TypeError`
3. There was a lot of repeated code, so I added a few extensible fixtures, so will be easy to make changes, but reduces code at the same time

### Example:
```py
from vetiver.server import predict
from vetiver.data import mtcars

endpoint = "http://127.0.0.1:8080/predict1"  # Notice incorrect URL

# res = predict(endpoint, data={1:2, 2:3})
res = predict(endpoint, data=mtcars)

print(res)
```

Before:
```py
Traceback (most recent call last):
  File "/home/ganesh/os/tmp/pred.py", line 7, in <module>
    res = predict(endpoint, data=mtcars)
  File "/home/ganesh/.local/lib/python3.10/site-packages/vetiver/server.py", line 265, in predict
    response_df = pd.DataFrame.from_dict(response.json())
  File "/home/ganesh/.local/lib/python3.10/site-packages/pandas/core/frame.py", line 1762, in from_dict
    return cls(data, index=index, columns=columns, dtype=dtype)
  File "/home/ganesh/.local/lib/python3.10/site-packages/pandas/core/frame.py", line 662, in __init__
    mgr = dict_to_mgr(data, index, columns, dtype=dtype, copy=copy, typ=manager)
  File "/home/ganesh/.local/lib/python3.10/site-packages/pandas/core/internals/construction.py", line 493, in dict_to_mgr
    return arrays_to_mgr(arrays, columns, index, dtype=dtype, typ=typ, consolidate=copy)
  File "/home/ganesh/.local/lib/python3.10/site-packages/pandas/core/internals/construction.py", line 118, in arrays_to_mgr
    index = _extract_index(arrays)
  File "/home/ganesh/.local/lib/python3.10/site-packages/pandas/core/internals/construction.py", line 656, in _extract_index
    raise ValueError("If using all scalar values, you must pass an index")
ValueError: If using all scalar values, you must pass an index

```

Now:
```py
Traceback (most recent call last):
  File "/home/ganesh/os/mlops/vetiver-python/pred.py", line 7, in <module>
    res = predict(endpoint, data=mtcars)
  File "/home/ganesh/os/mlops/vetiver-python/vetiver/server.py", line 270, in predict
    raise requests.exceptions.HTTPError(
requests.exceptions.HTTPError: Could not obtain data from endpoint with error: 404 Client Error: Not Found for url: http://127.0.0.1:8080/predict1
```

resolves: #71 

PS: Totally fine with getting rid of the extra stuff and just fixing the error, 81818dd2e004ad55fc8ac30a4774303a698eb1ef does that.