### PR TITLE
Make `vetiver_post` extensible for all endpoints

### DIFF
--- a/vetiver/server.py
+++ b/vetiver/server.py
@@ -70,7 +70,9 @@ class VetiverAPI:
         async def ping():
             return {"ping": "pong"}
 
-        self.vetiver_post(self.model.handler_predict, "predict", check_ptype=self.check_ptype)
+        self.vetiver_post(
+            self.model.handler_predict, "predict", check_ptype=self.check_ptype
+        )
 
         @app.get("/__docs__", response_class=HTMLResponse, include_in_schema=False)
         async def rapidoc():
@@ -111,10 +113,8 @@ class VetiverAPI:
             """
 
         return app
-    
-    def vetiver_post(
-        self, endpoint_fx: Callable, endpoint_name: str = None, **kw
-    ):
+
+    def vetiver_post(self, endpoint_fx: Callable, endpoint_name: str = None, **kw):
         """Create new POST endpoint that is aware of model input data
 
         Parameters
@@ -139,9 +139,11 @@ class VetiverAPI:
             endpoint_name = endpoint_fx.__name__
 
         if self.check_ptype is True:
-        
+
             @self.app.post("/" + endpoint_name, name=endpoint_name)
-            async def custom_endpoint(input_data: Union[self.model.ptype, List[self.model.ptype]]):
+            async def custom_endpoint(
+                input_data: Union[self.model.ptype, List[self.model.ptype]]
+            ):
 
                 if isinstance(input_data, List):
                     served_data = _batch_data(input_data)
@@ -197,10 +199,11 @@ class VetiverAPI:
         )
         openapi_schema["info"]["x-logo"] = {"url": "../docs/figures/logo.svg"}
         self.app.openapi_schema = openapi_schema
+
         return self.app.openapi_schema
 
 
-def predict(endpoint, data: Union[dict, pd.DataFrame, pd.Series], **kw):
+def predict(endpoint, data: Union[dict, pd.DataFrame, pd.Series], **kw) -> pd.DataFrame:
     """Make a prediction from model endpoint
 
     Parameters
@@ -257,14 +260,14 @@ def predict(endpoint, data: Union[dict, pd.DataFrame, pd.Series], **kw):
     return response_df
 
 
-def _prepare_data(pred_data):
+def _prepare_data(pred_data: list) -> list:
     served_data = []
     for key, value in pred_data:
         served_data.append(value)
     return served_data
 
 
-def _batch_data(pred_data):
+def _batch_data(pred_data) -> pd.DataFrame:
     columns = pred_data[0].dict().keys()
 
     data = [line.dict() for line in pred_data]
@@ -273,7 +276,7 @@ def _batch_data(pred_data):
     return served_data
 
 
-def vetiver_endpoint(url="http://127.0.0.1:8000/predict"):
+def vetiver_endpoint(url: str = "http://127.0.0.1:8000/predict") -> str:
     """Wrap url where VetiverModel will be deployed
 
     Parameters

--- a/vetiver/server.py
+++ b/vetiver/server.py
@@ -1,4 +1,4 @@
-from typing import Callable, List, Union, Any
+from typing import Callable, List, Union, Any, Dict
 from urllib.parse import urljoin
 
 import httpx
@@ -261,14 +261,14 @@ def predict(endpoint, data: Union[dict, pd.DataFrame, pd.Series], **kw) -> pd.Da
     return response_df
 
 
-def _prepare_data(pred_data: dict[str, Any]) -> list[Any]:
+def _prepare_data(pred_data: Dict[str, Any]) -> List[Any]:
     served_data = []
     for key, value in pred_data:
         served_data.append(value)
     return served_data
 
 
-def _batch_data(pred_data: list[Any]) -> pd.DataFrame:
+def _batch_data(pred_data: List[Any]) -> pd.DataFrame:
     columns = pred_data[0].dict().keys()
 
     data = [line.dict() for line in pred_data]

--- a/vetiver/server.py
+++ b/vetiver/server.py
@@ -1,16 +1,16 @@
-from fastapi import FastAPI, Request
-from fastapi.responses import HTMLResponse, RedirectResponse
-from fastapi.openapi.utils import get_openapi
-from fastapi import testclient
+from typing import Callable, List, Union
+from urllib.parse import urljoin
+
 import httpx
-
-import uvicorn
-import requests
 import pandas as pd
-from typing import Callable, Union, List
+import requests
+import uvicorn
+from fastapi import FastAPI, Request, testclient
+from fastapi.openapi.utils import get_openapi
+from fastapi.responses import HTMLResponse, RedirectResponse
 
-from .vetiver_model import VetiverModel
 from .utils import _jupyter_nb
+from .vetiver_model import VetiverModel
 
 
 class VetiverAPI:
@@ -140,7 +140,7 @@ class VetiverAPI:
 
         if self.check_ptype is True:
 
-            @self.app.post("/" + endpoint_name, name=endpoint_name)
+            @self.app.post(urljoin("/", endpoint_name), name=endpoint_name)
             async def custom_endpoint(
                 input_data: Union[self.model.ptype, List[self.model.ptype]]
             ):
@@ -155,7 +155,7 @@ class VetiverAPI:
 
         else:
 
-            @self.app.post("/" + endpoint_name)
+            @self.app.post(urljoin("/", endpoint_name))
             async def custom_endpoint(input_data: Request):
                 served_data = await input_data.json()
                 new = endpoint_fx(served_data, **kw)

--- a/vetiver/server.py
+++ b/vetiver/server.py
@@ -1,4 +1,4 @@
-from typing import Callable, List, Union
+from typing import Callable, List, Union, Any
 from urllib.parse import urljoin
 
 import httpx
@@ -232,6 +232,7 @@ def predict(endpoint, data: Union[dict, pd.DataFrame, pd.Series], **kw) -> pd.Da
         requester = requests
 
     # TO DO: arrow format
+    # TO DO: dispatch
 
     if isinstance(data, pd.DataFrame):
         data_json = data.to_json(orient="records")
@@ -260,14 +261,14 @@ def predict(endpoint, data: Union[dict, pd.DataFrame, pd.Series], **kw) -> pd.Da
     return response_df
 
 
-def _prepare_data(pred_data: list) -> list:
+def _prepare_data(pred_data: dict[str, Any]) -> list[Any]:
     served_data = []
     for key, value in pred_data:
         served_data.append(value)
     return served_data
 
 
-def _batch_data(pred_data) -> pd.DataFrame:
+def _batch_data(pred_data: list[Any]) -> pd.DataFrame:
     columns = pred_data[0].dict().keys()
 
     data = [line.dict() for line in pred_data]

--- a/vetiver/tests/test_add_endpoint.py
+++ b/vetiver/tests/test_add_endpoint.py
@@ -1,4 +1,5 @@
 from vetiver import mock, VetiverModel, VetiverAPI
+import pandas as pd
 from fastapi.testclient import TestClient
 
 
@@ -27,7 +28,7 @@ def test_endpoint_adds_ptype():
     app = _start_application(check_ptype=True).app
 
     client = TestClient(app)
-    data = {"B": 0, "C": 0, "D": 0}
+    data = {"B": [0], "C": [0], "D": [0]}
     response = client.post("/sum", json=data)
     assert response.status_code == 200, response.text
     assert response.json() == {"sum": [0]}, response.json()

--- a/vetiver/tests/test_add_endpoint.py
+++ b/vetiver/tests/test_add_endpoint.py
@@ -1,6 +1,7 @@
 from vetiver import mock, VetiverModel, VetiverAPI
 import pandas as pd
 from fastapi.testclient import TestClient
+from fastapi.encoders import jsonable_encoder
 
 
 def _start_application(check_ptype):
@@ -15,6 +16,7 @@ def _start_application(check_ptype):
     )
 
     def sum_values(x):
+        x = pd.DataFrame(jsonable_encoder(x))
         return x.sum()
 
     app = VetiverAPI(v, check_ptype=check_ptype)
@@ -25,20 +27,23 @@ def _start_application(check_ptype):
 
 
 def test_endpoint_adds_ptype():
+
     app = _start_application(check_ptype=True).app
 
     client = TestClient(app)
-    data = {"B": [0], "C": [0], "D": [0]}
+    data = {"B": [1, 1, 1], "C": [2, 2, 2], "D": [3, 3, 3]}
     response = client.post("/sum", json=data)
+
     assert response.status_code == 200, response.text
-    assert response.json() == {"sum": [0]}, response.json()
+    assert response.json() == {"sum": [3, 6, 9]}, response.json()
 
 
 def test_endpoint_adds_no_ptype():
     app = _start_application(check_ptype=False).app
 
     client = TestClient(app)
-    data = [0, 0, 0]
+    data = {"B": [1, 1, 1], "C": [2, 2, 2], "D": [3, 3, 3]}
     response = client.post("/sum", json=data)
+
     assert response.status_code == 200, response.text
-    assert response.json() == {"sum": [0]}, response.json()
+    assert response.json() == {"sum": [3, 6, 9]}, response.json()

--- a/vetiver/tests/test_add_endpoint.py
+++ b/vetiver/tests/test_add_endpoint.py
@@ -28,6 +28,11 @@ def sum_values(x):
     return x.sum()
 
 
+def sum_dict(x):
+    x = pd.DataFrame(x)
+    return x.sum()
+
+
 @pytest.fixture
 def vetiver_client(vetiver_model):  # With check_ptype=True
 
@@ -44,7 +49,7 @@ def vetiver_client(vetiver_model):  # With check_ptype=True
 def vetiver_client_check_ptype_false(vetiver_model):  # With check_ptype=False
 
     app = VetiverAPI(vetiver_model, check_ptype=False)
-    app.vetiver_post(sum_values, "sum")
+    app.vetiver_post(sum_dict, "sum")
 
     app.app.root_path = "/sum"
     client = TestClient(app.app)
@@ -66,5 +71,5 @@ def test_endpoint_adds_no_ptype(vetiver_client_check_ptype_false):
     data = pd.DataFrame({"B": [1, 1, 1], "C": [2, 2, 2], "D": [3, 3, 3]})
     response = vetiver.predict(endpoint=vetiver_client_check_ptype_false, data=data)
 
-    assert response.status_code == 200, response.text
-    assert response.json() == {"sum": [3, 6, 9]}, response.json()
+    assert isinstance(response, pd.DataFrame)
+    assert response.to_json() == '{"sum":{"0":3,"1":6,"2":9}}', response.to_json()

--- a/vetiver/tests/test_pytorch.py
+++ b/vetiver/tests/test_pytorch.py
@@ -66,7 +66,7 @@ def test_torch_predict_ptype():
     response = client.post("/predict", json=data)
 
     assert response.status_code == 200, response.text
-    assert response.json() == {"prediction": [-4.060722351074219]}, response.text
+    assert response.json() == {"predict": [-4.060722351074219]}, response.text
 
 
 def test_torch_predict_ptype_batch():
@@ -81,7 +81,7 @@ def test_torch_predict_ptype_batch():
 
     assert response.status_code == 200, response.text
     assert response.json() == {
-        "prediction": [[-4.060722351074219], [-4.060722351074219]]
+        "predict": [[-4.060722351074219], [-4.060722351074219]]
     }, response.text
 
 
@@ -109,7 +109,7 @@ def test_torch_predict_no_ptype_batch():
     response = client.post("/predict", json=data)
     assert response.status_code == 200, response.text
     assert response.json() == {
-        "prediction": [[-4.060722351074219], [-4.060722351074219]]
+        "predict": [[-4.060722351074219], [-4.060722351074219]]
     }, response.text
 
 
@@ -123,4 +123,4 @@ def test_torch_predict_no_ptype():
     data = [[3.3]]
     response = client.post("/predict", json=data)
     assert response.status_code == 200, response.text
-    assert response.json() == {"prediction": [[-4.060722351074219]]}, response.text
+    assert response.json() == {"predict": [[-4.060722351074219]]}, response.text

--- a/vetiver/tests/test_sklearn.py
+++ b/vetiver/tests/test_sklearn.py
@@ -26,7 +26,7 @@ def test_predict_endpoint_ptype():
     data = {"B": 0, "C": 0, "D": 0}
     response = client.post("/predict", json=data)
     assert response.status_code == 200, response.text
-    assert response.json() == {"prediction": [44.47]}, response.json()
+    assert response.json() == {"predict": [44.47]}, response.json()
 
 
 def test_predict_endpoint_ptype_batch():
@@ -35,7 +35,7 @@ def test_predict_endpoint_ptype_batch():
     data = [{"B": 0, "C": 0, "D": 0}, {"B": 0, "C": 0, "D": 0}]
     response = client.post("/predict", json=data)
     assert response.status_code == 200, response.text
-    assert response.json() == {"prediction": [44.47, 44.47]}, response.json()
+    assert response.json() == {"predict": [44.47, 44.47]}, response.json()
 
 
 def test_predict_endpoint_ptype_error():
@@ -52,7 +52,7 @@ def test_predict_endpoint_no_ptype():
     data = [{"B": 0, "C": 0, "D": 0}]
     response = client.post("/predict", json=data)
     assert response.status_code == 200, response.text
-    assert response.json() == {"prediction": [44.47]}, response.json()
+    assert response.json() == {"predict": [44.47]}, response.json()
 
 
 def test_predict_endpoint_no_ptype_batch():
@@ -61,7 +61,7 @@ def test_predict_endpoint_no_ptype_batch():
     data = [[0, 0, 0], [0, 0, 0]]
     response = client.post("/predict", json=data)
     assert response.status_code == 200, response.text
-    assert response.json() == {"prediction": [44.47, 44.47]}, response.json()
+    assert response.json() == {"predict": [44.47, 44.47]}, response.json()
 
 
 def test_predict_endpoint_no_ptype_error():


### PR DESCRIPTION
- removes the creation of a specific `/predict`, rather, will use arguments in `vetiver_post`
- refactor tests to reflect this
