### PR TITLE
rsconnect-python>=1.12.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     nest-asyncio
     requests
     pins
-    rsconnect-python
+    rsconnect-python>=1.12.1
     plotly
     pip-tools
     httpx

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     nest-asyncio
     requests
     pins
-    rsconnect-python>=1.12.1
+    rsconnect-python>=1.8.0
     plotly
     pip-tools
     httpx


### PR DESCRIPTION
Require rsconnect-python>=1.12.1.

Closes #131.