### PR TITLE
Changing language from "Example" to "Examples" for docstrings

### DIFF
--- a/vetiver/monitor.py
+++ b/vetiver/monitor.py
@@ -31,7 +31,7 @@ def compute_metrics(
     estimate:
         Column name for predicted results
 
-    Example
+    Examples
     -------
     >>> from datetime import timedelta
     >>> import pandas as pd
@@ -115,7 +115,7 @@ def pin_metrics(
         If False, error when the new metrics contain overlapping dates with
         the existing pin.
 
-    Example
+    Examples
     -------
     >>> import pins
     >>> import vetiver
@@ -215,7 +215,7 @@ def plot_metrics(
     n: str
         Column in `df_metrics` containing number of observations
 
-    Example
+    Examples
     -------
     >>> import vetiver
     >>> import pandas as pd

--- a/vetiver/pin_read_write.py
+++ b/vetiver/pin_read_write.py
@@ -32,7 +32,7 @@ def vetiver_pin_write(board, model: VetiverModel, versioned: bool = True):
     versioned: bool
         Whether or not the pin should be versioned
 
-    Example
+    Examples
     -------
     >>> import vetiver
     >>> from pins import board_temp

--- a/vetiver/rsconnect.py
+++ b/vetiver/rsconnect.py
@@ -54,8 +54,8 @@ def deploy_rsconnect(
     image : str
         Docker image to be specified for off-host execution
 
-    Example
-    -------
+    Examples
+    ------
     >>> import vetiver
     >>> import pins
     >>> import rsconnect

--- a/vetiver/rsconnect.py
+++ b/vetiver/rsconnect.py
@@ -55,7 +55,7 @@ def deploy_rsconnect(
         Docker image to be specified for off-host execution
 
     Examples
-    ------
+    -------
     >>> import vetiver
     >>> import pins
     >>> import rsconnect

--- a/vetiver/server.py
+++ b/vetiver/server.py
@@ -29,7 +29,7 @@ class VetiverAPI:
     **kwargs: dict
         Deprecated parameters.
 
-    Example
+    Examples
     -------
     >>> import vetiver as vt
     >>> X, y = vt.get_mock_data()
@@ -150,7 +150,7 @@ class VetiverAPI:
         endpoint_name : str
             Name of endpoint
 
-        Example
+        Examples
         -------
         >>> import vetiver as vt
         >>> X, y = vt.get_mock_data()
@@ -199,7 +199,7 @@ class VetiverAPI:
         host : str
             A valid IPv4 or IPv6 address, which the application will listen on.
 
-        Example
+        Examples
         -------
         >>> import vetiver as vt
         >>> X, y = vt.get_mock_data()
@@ -244,7 +244,7 @@ def predict(endpoint, data: Union[dict, pd.DataFrame, pd.Series], **kw) -> pd.Da
     dict
         Endpoint_name and list of endpoint_fx output
 
-    Example
+    Examples
     -------
     >>> import vetiver
     >>> X, y = vetiver.get_mock_data()
@@ -316,7 +316,7 @@ def vetiver_endpoint(url: str = "http://127.0.0.1:8000/predict") -> str:
     url : str
         URI path to endpoint
 
-    Example
+    Examples
     -------
     >>> import vetiver
     >>> endpoint = vetiver.vetiver_endpoint(url='http://127.0.0.1:8000/predict')

--- a/vetiver/vetiver_model.py
+++ b/vetiver/vetiver_model.py
@@ -54,7 +54,7 @@ class VetiverModel:
 
 
 
-    Example
+    Examples
     -------
     >>> from vetiver import mock, VetiverModel
     >>> X, y = mock.get_mock_data()

--- a/vetiver/write_docker.py
+++ b/vetiver/write_docker.py
@@ -47,7 +47,7 @@ def write_docker(
         port: str
             Port to run VetiverAPI from Dockerfile
 
-    Example
+    Examples
     -------
     >>> import vetiver
     >>> import tempfile

--- a/vetiver/write_fastapi.py
+++ b/vetiver/write_fastapi.py
@@ -67,7 +67,7 @@ def write_app(
     file :
         Name of file
 
-    Example
+    Examples
     -------
     >>> import vetiver
     >>> import tempfile


### PR DESCRIPTION
Sphinx is not picky about the exact language to generate "Example" code sections. However, for quartodoc, the word must be "Example*s*" to be understood as a code chunk. This change updates all places where Example is used to be compliant.

see https://github.com/machow/quartodoc/issues/10 for more information.
