### PR TITLE
[FIX] None type handling for `python_version` in metadata

### DIFF
--- a/vetiver/meta.py
+++ b/vetiver/meta.py
@@ -26,8 +26,14 @@ class VetiverMeta:
         user = metadata.get("user", metadata)
         version = metadata.get("version", None)
         url = metadata.get("url", None)
-        required_pkgs = metadata.get("required_pkgs", [])
-        python_version = tuple(metadata.get("python_version", sys.version_info))
+        # give correct value if key doesnt exist or if value is None
+        required_pkgs = (
+            []
+            if not metadata.get("required_pkgs")
+            else metadata.get("required_pkgs", [])
+        )
+        python_version = metadata.get("python_version", sys.version_info)
+        python_version = python_version if not python_version else tuple(python_version)
 
         if pip_name:
             if not list(filter(lambda x: pip_name in x, required_pkgs)):

--- a/vetiver/pin_read_write.py
+++ b/vetiver/pin_read_write.py
@@ -70,7 +70,9 @@ def vetiver_pin_write(board, model: VetiverModel, versioned: bool = True):
             "vetiver_meta": {
                 "required_pkgs": model.metadata.required_pkgs,
                 "prototype": None if not model.prototype else model.prototype().json(),
-                "python_version": list(model.metadata.python_version),
+                "python_version": None
+                if not model.metadata.python_version
+                else list(model.metadata.python_version),
             },
         },
         versioned=versioned,

--- a/vetiver/tests/test_build_vetiver_model.py
+++ b/vetiver/tests/test_build_vetiver_model.py
@@ -177,3 +177,29 @@ def test_vetiver_model_from_pin_user_metadata():
     assert v2.metadata.python_version == tuple(custom_meta["python_version"])
 
     board.pin_delete("model")
+
+
+def test_vetiver_model_from_pin_no_version():
+    """
+    Test if standard keys as part of :dataclass:`VetiverMeta` are picked
+    """
+    custom_meta = {
+        "required_pkgs": None,
+        "python_version": None,
+    }
+
+    v = vt.VetiverModel(
+        model=model,
+        prototype_data=X_df,
+        model_name="model",
+        metadata=custom_meta,
+    )
+
+    board = pins.board_temp(allow_pickle_read=True)
+    vt.vetiver_pin_write(board=board, model=v)
+    v2 = vt.VetiverModel.from_pin(board, "model")
+
+    assert v2.metadata.required_pkgs == ["scikit-learn"]
+    assert v2.metadata.python_version is None
+
+    board.pin_delete("model")


### PR DESCRIPTION
closes #148 

This bug occurs when the `python_version` metadata field is `None` (since None cannot be coerced into a tuple). This also adds tests around if no Python version is supplied at `pin_read`, no Python version is populated. The idea is that we do not overwrite/populate Python versions of models being read from pins.