### PR TITLE
Match GHA Python versions to Connect

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         # Minimum and Maximum supported versions
-        python-version: ['3.9.5']
+        python-version: ['3.10']
 
 
     steps:
@@ -103,7 +103,7 @@ jobs:
     strategy:
       matrix:
         # Minimum and Maximum supported versions
-        python-version: ['3.10']
+        python-version: ['3.9']
 
     steps:
       - name: Get latest release with tag from GitHub API
@@ -150,7 +150,7 @@ jobs:
     strategy:
       matrix:
         # Minimum and Maximum supported versions
-        python-version: ['3.10']
+        python-version: ['3.9']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -9,6 +9,8 @@ name: Weekly Tests
 on:
   schedule:
     - cron: "03 14 * * MON"
+  push:
+    branches: ['update-weekly']
 
 jobs:
   vetiver_main_pins_main:
@@ -19,7 +21,7 @@ jobs:
     strategy:
       matrix:
         # Minimum and Maximum supported versions
-        python-version: ['3.10']
+        python-version: ['3.9.5']
 
 
     steps:


### PR DESCRIPTION
Connect requires matching Python versions to deploy, so I updated the tests to match what is installed in Connect.

This should fix weekly tests 👍 