### PR TITLE
[DOCS] update docs to look less like vetiver.rstudio.com

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/docs/_extensions/machow/interlinks/_extension.yml
+++ b/docs/_extensions/machow/interlinks/_extension.yml
@@ -4,4 +4,4 @@ version: 1.0.0
 quarto-required: ">=1.2.0"
 contributes:
   filters:
-    - interlinks.py
+    - interlinks.lua

--- a/docs/_extensions/machow/interlinks/interlinks.lua
+++ b/docs/_extensions/machow/interlinks/interlinks.lua
@@ -1,0 +1,183 @@
+local function read_json(filename)
+    local file = io.open(filename, "r")
+    if file == nil then
+        return nil
+    end
+    local str = file:read("a")
+    file:close()
+    return quarto.json.decode(str)
+end
+
+local inventory = {}
+
+function lookup(search_object)
+
+    local results = {}
+    for ii, inventory in ipairs(inventory) do
+        for jj, item in ipairs(inventory.items) do
+            -- e.g. :external+<inv_name>:<domain>:<role>:`<name>`
+            if item.inv_name and item.inv_name ~= search_object.inv_name then
+                goto continue
+            end
+
+            if item.name ~= search_object.name then
+                goto continue
+            end
+
+            if search_object.role and item.role ~= search_object.role then
+                goto continue
+            end
+
+            if search_object.domain and item.domain ~= search_object.domain then
+                goto continue
+            else
+                table.insert(results, item)
+
+                goto continue
+            end
+
+            ::continue::
+        end
+    end
+
+    if #results == 1 then
+        return results[1]
+    end
+    if #results > 1 then
+        print("Found multiple matches for " .. search_object.name)
+        quarto.utils.dump(results)
+        return nil
+    end
+    if #results == 0 then
+        print("Found no matches for object:")
+        quarto.utils.dump(search_object)
+    end
+
+    return nil
+end
+
+function mysplit (inputstr, sep)
+    if sep == nil then
+            sep = "%s"
+    end
+    local t={}
+    for str in string.gmatch(inputstr, "([^"..sep.."]+)") do
+            table.insert(t, str)
+    end
+    return t
+end
+
+local function normalize_role(role)
+    if role == "func" then
+        return "function"
+    end
+    return role
+end
+
+local function build_search_object(str)
+    local starts_with_colon = str:sub(1, 1) == ":"
+    local search = {}
+    if starts_with_colon then
+        local t = mysplit(str, ":")
+        if #t == 2 then
+            -- e.g. :py:func:`my_func`
+            search.role = normalize_role(t[1])
+            search.name = t[2]:match("%%60(.*)%%60")
+        elseif #t == 3 then
+            -- e.g. :py:func:`my_func`
+            search.domain = t[1]
+            search.role = normalize_role(t[2])
+            search.name = t[3]:match("%%60(.*)%%60")
+        elseif #t == 4 then
+            -- e.g. :ext+inv:py:func:`my_func`
+            search.external = true
+
+            search.inv_name = t[1]:match("external%+(.*)")
+            search.domain = t[2]
+            search.role = normalize_role(t[3])
+            search.name = t[4]:match("%%60(.*)%%60")
+        else
+            print("couldn't parse this link: " .. str)
+            return {}
+        end
+    else
+        search.name = str:match("%%60(.*)%%60")
+    end
+
+    if search.name == nil then
+        print("couldn't parse this link: " .. str)
+        return {}
+    end
+
+    if search.name:sub(1, 1) == "~" then
+        search.shortened = true
+        search.name = search.name:sub(2, -1)
+    end
+    return search
+end
+
+function report_broken_link(link, search_object, replacement)
+    -- TODO: how to unescape html elements like [?
+    return pandoc.Code(pandoc.utils.stringify(link.content))
+end
+
+function Link(link)
+    -- do not process regular links ----
+    if not link.target:match("%%60") then
+        return link
+    end
+
+    -- lookup item ----
+    local search = build_search_object(link.target)
+    local item = lookup(search)
+
+    -- determine replacement, used if no link text specified ----
+    local original_text = pandoc.utils.stringify(link.content)
+    local replacement = search.name
+    if search.shortened then
+        local t = mysplit(search.name, ".")
+        replacement = t[#t]
+    end
+
+    -- set link text ----
+    if original_text == "" then
+        link.content = replacement
+    end
+
+    -- report broken links ----
+    if item == nil then
+        return report_broken_link(link, search)
+    end
+    link.target = item.uri:gsub("%$$", search.name)
+
+
+    return link
+end
+
+function fixup_json(json, prefix)
+    for _, item in ipairs(json.items) do
+        item.uri = prefix .. item.uri
+    end
+    table.insert(inventory, json)
+end
+
+return {
+    {
+        Meta = function(meta)
+            local json
+            local prefix
+            for k, v in pairs(meta.interlinks.sources) do
+                json = read_json(quarto.project.offset .. "/_inv/" .. k .. "_objects.json")
+                prefix = pandoc.utils.stringify(v.url)
+                fixup_json(json, prefix)
+            end
+            json = read_json(quarto.project.offset .. "/objects.json")
+            if json ~= nil then
+                fixup_json(json, "/")
+            end
+        end
+    },
+    {
+        Link = Link
+    }
+}

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -4,7 +4,7 @@ project:
   output-dir: _site
 
 website:
-  title: "Vetiver (Python)"
+  title: "vetiver for Python"
   description: "Version, share, deploy, and monitor your Python models"
   repo-url: https://github.com/rstudio/vetiver-python
   repo-actions: [edit, issue]
@@ -22,7 +22,7 @@ website:
         href: https://github.com/rstudio/vetiver-python
         aria-label: Vetiver python GitHub
   navbar:
-    background: primary
+    background: light
     pinned: true
     logo: "figures/logo.svg"
     logo-alt: "vetiver-home"
@@ -48,7 +48,7 @@ website:
 
 quartodoc:
   style: pkgdown
-  title: "Vetiver-{{< env VERSION >}}"
+  title: "Vetiver:v{{< env VERSION >}}"
   package: vetiver
   renderer:
     style: markdown
@@ -66,7 +66,8 @@ quartodoc:
     - title: Deploy
       desc: ""
       contents:
-        - VetiverAPI
+        - name: VetiverAPI
+          children: linked
         - VetiverAPI.run
         - VetiverAPI.vetiver_post
         - vetiver_endpoint
@@ -98,7 +99,7 @@ metadata-files:
 
 filters:
   - interlinks
-
+  
 interlinks:
   sources: {}
 
@@ -107,4 +108,7 @@ profile:
 
 format:
   html:
-    theme: sandstone
+    theme: 
+      - sandstone
+      - style.css
+

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -99,7 +99,7 @@ metadata-files:
 
 filters:
   - interlinks
-  
+
 interlinks:
   sources: {}
 
@@ -108,7 +108,6 @@ profile:
 
 format:
   html:
-    theme: 
+    theme:
       - sandstone
       - style.css
-

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -15,7 +15,7 @@ website:
       Proudly supported by
       [![](https://www.rstudio.com/assets/img/posit-logo-fullcolor-TM.svg){fig-alt="Posit PBC" width=65px}](https://posit.co/)
     center:
-      - text: "Main site"
+      - text: "vetiver.rstudio.com"
         href: https://vetiver.rstudio.com
     right:
       - icon: github
@@ -35,8 +35,12 @@ website:
           - custom_handler.md
       - text: "Changelog"
         file: changelog.md
-      - text: "Vetiver main site"
-        href: https://vetiver.rstudio.com
+      - text: "Learn more"
+        menu:
+          - text: "vetiver.rstudio.com"
+            href: https://vetiver.rstudio.com
+          - text: "R package documentation"
+            href: https://rstudio.github.io/vetiver-python/
 
   sidebar:
     - id: reference
@@ -46,7 +50,6 @@ quartodoc:
   style: pkgdown
   title: "Vetiver-{{< env VERSION >}}"
   package: vetiver
-  display_name: relative
   renderer:
     style: markdown
     display_name: relative

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -7,20 +7,12 @@ website:
   title: "Vetiver for Python"
   description: "Version, share, deploy, and monitor your Python models"
   repo-url: https://github.com/rstudio/vetiver-python
-  repo-actions: [edit, issue]
   page-navigation: true
   favicon: "figures/logo.svg"
   page-footer:
     left: |
       Proudly supported by
       [![](https://www.rstudio.com/assets/img/posit-logo-fullcolor-TM.svg){fig-alt="Posit PBC" width=65px}](https://posit.co/)
-    center:
-      - text: "vetiver.rstudio.com"
-        href: https://vetiver.rstudio.com
-    right:
-      - icon: github
-        href: https://github.com/rstudio/vetiver-python
-        aria-label: Vetiver python GitHub
   navbar:
     background: "#562910"
     pinned: true
@@ -41,6 +33,10 @@ website:
             href: https://vetiver.rstudio.com
           - text: "R package documentation"
             href: https://rstudio.github.io/vetiver-r/reference/
+    right:
+      - icon: github
+        href: https://github.com/rstudio/vetiver-python
+        aria-label: Vetiver python GitHub
 
   sidebar:
     - id: reference

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -4,7 +4,7 @@ project:
   output-dir: _site
 
 website:
-  title: "vetiver for Python"
+  title: "Vetiver for Python"
   description: "Version, share, deploy, and monitor your Python models"
   repo-url: https://github.com/rstudio/vetiver-python
   repo-actions: [edit, issue]
@@ -22,7 +22,7 @@ website:
         href: https://github.com/rstudio/vetiver-python
         aria-label: Vetiver python GitHub
   navbar:
-    background: light
+    background: "#562910"
     pinned: true
     logo: "figures/logo.svg"
     logo-alt: "vetiver-home"
@@ -40,7 +40,7 @@ website:
           - text: "vetiver.rstudio.com"
             href: https://vetiver.rstudio.com
           - text: "R package documentation"
-            href: https://rstudio.github.io/vetiver-python/
+            href: https://rstudio.github.io/vetiver-r/reference/
 
   sidebar:
     - id: reference
@@ -109,5 +109,4 @@ profile:
 format:
   html:
     theme:
-      - sandstone
-      - style.css
+      - flatly

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -4,13 +4,13 @@ project:
   output-dir: _site
 
 website:
-  title: "Vetiver for Python"
+  title: "vetiver for Python"
   description: "Version, share, deploy, and monitor your Python models"
   repo-url: https://github.com/rstudio/vetiver-python
   page-navigation: true
   favicon: "figures/logo.svg"
   page-footer:
-    left: |
+    center: |
       Proudly supported by
       [![](https://www.rstudio.com/assets/img/posit-logo-fullcolor-TM.svg){fig-alt="Posit PBC" width=65px}](https://posit.co/)
   navbar:
@@ -31,8 +31,10 @@ website:
         menu:
           - text: "vetiver.rstudio.com"
             href: https://vetiver.rstudio.com
+            target: _blank
           - text: "R package documentation"
             href: https://rstudio.github.io/vetiver-r/reference/
+            target: _blank
     right:
       - icon: github
         href: https://github.com/rstudio/vetiver-python

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,7 +1,0 @@
-/*-- scss:defaults --*/
-.nav-link {
-    color: #7f3c18    !important;
-    }
-.navbar-title{
-    color:#7f3c18
-}

--- a/docs/style.css
+++ b/docs/style.css
@@ -3,5 +3,5 @@
     color: #7f3c18    !important;
     }
 .navbar-title{
-    color:#7f3c18  
+    color:#7f3c18
 }

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,7 @@
+/*-- scss:defaults --*/
+.nav-link {
+    color: #7f3c18    !important;
+    }
+.navbar-title{
+    color:#7f3c18  
+}

--- a/vetiver/vetiver_model.py
+++ b/vetiver/vetiver_model.py
@@ -93,7 +93,18 @@ class VetiverModel:
 
     @classmethod
     def from_pin(cls, board, name: str, version: str = None):
+        """
+        Create VetiverModel from pinned model.
 
+        Parameters
+        ----------
+        board :
+            `pins` board where model is located
+        name : str
+            Model name inside pins board
+        version : str
+            What model version should be loaded
+        """
         model = board.pin_read(name, version)
         meta = board.pin_meta(name, version)
 


### PR DESCRIPTION
After gathering community feedback, we may have made **too** unified of a look between the Python package docs and vetiver.rstudio.com. This PR is to update the look as well as add in links to the R package docs