### PR TITLE
[MAINT] require no less than pins 0.7.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     scikit-learn
     nest-asyncio
     requests
-    pins
+    pins>=0.7.1
     rsconnect-python>=1.8.0
     plotly
     pip-tools


### PR DESCRIPTION
Related to https://github.com/rstudio/vetiver-r/issues/224, this will prevent incompatible pins versions from being used.