### PR TITLE
ENH: add `root_path` if user in posit workbench

### DIFF
--- a/vetiver/server.py
+++ b/vetiver/server.py
@@ -1,26 +1,27 @@
-from typing import Callable, List, Union
-from urllib.parse import urljoin
-
 import re
 import httpx
 import json
-import pandas as pd
 import requests
 import uvicorn
 import os
 import subprocess
+import logging
+import pandas as pd
 from fastapi import FastAPI, Request, testclient
 from fastapi.exceptions import RequestValidationError
 from fastapi.openapi.utils import get_openapi
-from fastapi.responses import HTMLResponse, RedirectResponse
-from fastapi.responses import PlainTextResponse
+from fastapi.responses import HTMLResponse, RedirectResponse, PlainTextResponse
 from textwrap import dedent
 from warnings import warn
+from urllib.parse import urljoin
+from typing import Callable, List, Union
 
-from .utils import _jupyter_nb
+from .utils import _jupyter_nb, inform
 from .vetiver_model import VetiverModel
 from .meta import VetiverMeta
 from .helpers import api_data_to_frame, response_to_frame
+
+_log = logging.getLogger(__name__)
 
 
 class VetiverAPI:
@@ -278,9 +279,10 @@ class VetiverAPI:
             )
         # subprocess is run, new URL given
         if len(path) > 0:
-            print(f"INFO:    vetiver running at: {path}")
+            inform(_log, f"INFO:     vetiver running at: {path}")
             uvicorn.run(self.app, port=port, host=host, root_path=path, **kw)
         else:
+            inform(_log, f"INFO:     vetiver running at: {host+':'+port}")
             uvicorn.run(self.app, port=port, host=host, **kw)
 
     def _custom_openapi(self):

--- a/vetiver/server.py
+++ b/vetiver/server.py
@@ -265,6 +265,7 @@ class VetiverAPI:
         _jupyter_nb()
         # check to see if in Posit Workbench, pulled from FastAPI section of user guide
         # https://docs.posit.co/ide/server-pro/user/vs-code/guide/proxying-web-servers.html#running-fastapi-with-uvicorn # noqa
+        path = ""
         if "RS_SERVER_URL" in os.environ and os.environ["RS_SERVER_URL"]:
             path = (
                 subprocess.run(
@@ -275,6 +276,9 @@ class VetiverAPI:
                 .stdout.decode()
                 .strip()
             )
+        # subprocess is run, new URL given
+        if len(path) > 0:
+            print(f"INFO:    vetiver running at: {path}")
             uvicorn.run(self.app, port=port, host=host, root_path=path, **kw)
         else:
             uvicorn.run(self.app, port=port, host=host, **kw)

--- a/vetiver/tests/test_xgboost.py
+++ b/vetiver/tests/test_xgboost.py
@@ -57,7 +57,7 @@ def test_vetiver_build(vetiver_client):
 
     response = vetiver.predict(endpoint=vetiver_client, data=data)
 
-    assert response.iloc[0, 0] == 21.064373016357422
+    assert response.iloc[0, 0] == 19.963224411010742
     assert len(response) == 1
 
 
@@ -66,7 +66,7 @@ def test_batch(vetiver_client):
 
     response = vetiver.predict(endpoint=vetiver_client, data=data)
 
-    assert response.iloc[0, 0] == 21.064373016357422
+    assert response.iloc[0, 0] == 19.963224411010742
     assert len(response) == 3
 
 
@@ -75,7 +75,7 @@ def test_no_ptype(vetiver_client_check_ptype_false):
 
     response = vetiver.predict(endpoint=vetiver_client_check_ptype_false, data=data)
 
-    assert response.iloc[0, 0] == 21.064373016357422
+    assert response.iloc[0, 0] == 19.963224411010742
     assert len(response) == 1
 
 

--- a/vetiver/tests/test_xgboost.py
+++ b/vetiver/tests/test_xgboost.py
@@ -64,7 +64,7 @@ def test_vetiver_build(vetiver_client):
 
     response = vetiver.predict(endpoint=vetiver_client, data=data)
 
-    assert response.iloc[0, 0] == 19.963224411010742
+    assert response.iloc[0, 0] == PREDICT_VALUE
     assert len(response) == 1
 
 
@@ -73,7 +73,7 @@ def test_batch(vetiver_client):
 
     response = vetiver.predict(endpoint=vetiver_client, data=data)
 
-    assert response.iloc[0, 0] == 19.963224411010742
+    assert response.iloc[0, 0] == PREDICT_VALUE
     assert len(response) == 3
 
 
@@ -82,7 +82,7 @@ def test_no_ptype(vetiver_client_check_ptype_false):
 
     response = vetiver.predict(endpoint=vetiver_client_check_ptype_false, data=data)
 
-    assert response.iloc[0, 0] == 19.963224411010742
+    assert response.iloc[0, 0] == PREDICT_VALUE
     assert len(response) == 1
 
 

--- a/vetiver/tests/test_xgboost.py
+++ b/vetiver/tests/test_xgboost.py
@@ -5,9 +5,16 @@ xgb = pytest.importorskip("xgboost", reason="xgboost library not installed")
 from vetiver.data import mtcars  # noqa
 from vetiver.handlers.xgboost import XGBoostHandler  # noqa
 import numpy as np  # noqa
+import sys  # noqa
 from fastapi.testclient import TestClient  # noqa
 
 import vetiver  # noqa
+
+# hack since xgboost 2.0 dropped 3.7 support
+if sys.version_info[0] == 3 and sys.version_info[1] < 8:
+    PREDICT_VALUE = 21.064373016357422
+else:
+    PREDICT_VALUE = 19.963224411010742
 
 
 @pytest.fixture
@@ -57,7 +64,7 @@ def test_vetiver_build(vetiver_client):
 
     response = vetiver.predict(endpoint=vetiver_client, data=data)
 
-    assert response.iloc[0, 0] == 21.064373016357422
+    assert response.iloc[0, 0] == 19.963224411010742
     assert len(response) == 1
 
 
@@ -66,7 +73,7 @@ def test_batch(vetiver_client):
 
     response = vetiver.predict(endpoint=vetiver_client, data=data)
 
-    assert response.iloc[0, 0] == 21.064373016357422
+    assert response.iloc[0, 0] == 19.963224411010742
     assert len(response) == 3
 
 
@@ -75,7 +82,7 @@ def test_no_ptype(vetiver_client_check_ptype_false):
 
     response = vetiver.predict(endpoint=vetiver_client_check_ptype_false, data=data)
 
-    assert response.iloc[0, 0] == 21.064373016357422
+    assert response.iloc[0, 0] == 19.963224411010742
     assert len(response) == 1
 
 

--- a/vetiver/tests/test_xgboost.py
+++ b/vetiver/tests/test_xgboost.py
@@ -57,7 +57,7 @@ def test_vetiver_build(vetiver_client):
 
     response = vetiver.predict(endpoint=vetiver_client, data=data)
 
-    assert response.iloc[0, 0] == 19.963224411010742
+    assert response.iloc[0, 0] == 21.064373016357422
     assert len(response) == 1
 
 
@@ -66,7 +66,7 @@ def test_batch(vetiver_client):
 
     response = vetiver.predict(endpoint=vetiver_client, data=data)
 
-    assert response.iloc[0, 0] == 19.963224411010742
+    assert response.iloc[0, 0] == 21.064373016357422
     assert len(response) == 3
 
 
@@ -75,7 +75,7 @@ def test_no_ptype(vetiver_client_check_ptype_false):
 
     response = vetiver.predict(endpoint=vetiver_client_check_ptype_false, data=data)
 
-    assert response.iloc[0, 0] == 19.963224411010742
+    assert response.iloc[0, 0] == 21.064373016357422
     assert len(response) == 1
 
 

--- a/vetiver/utils.py
+++ b/vetiver/utils.py
@@ -1,6 +1,8 @@
 import nest_asyncio
 import warnings
 import sys
+import os
+import subprocess
 from types import SimpleNamespace
 
 no_notebook = False
@@ -14,8 +16,8 @@ def _jupyter_nb():
 
     if not no_notebook:
         warnings.warn(
-            "WARNING: Jupyter Notebooks are not considered stable environments "
-            "for production code"
+            "You may be running from a notebook environment. Jupyter Notebooks are "
+            "not considered stable environments for production code"
         )
         nest_asyncio.apply()
     else:
@@ -31,3 +33,23 @@ def inform(log, msg):
 
     if not modelcard_options.quiet:
         print(msg, file=sys.stderr)
+
+
+def get_workbench_path(port):
+    # check to see if in Posit Workbench, pulled from FastAPI section of user guide
+    # https://docs.posit.co/ide/server-pro/user/vs-code/guide/proxying-web-servers.html#running-fastapi-with-uvicorn # noqa
+
+    if "RS_SERVER_URL" in os.environ and os.environ["RS_SERVER_URL"]:
+        path = (
+            subprocess.run(
+                f"echo $(/usr/lib/rstudio-server/bin/rserver-url -l {port})",
+                stdout=subprocess.PIPE,
+                shell=True,
+            )
+            .stdout.decode()
+            .strip()
+        )
+        # subprocess is run, new URL given
+        return path
+    else:
+        return None


### PR DESCRIPTION
Adding support for Posit Workbench. If a user starts a local API in Workbench, automatically set root_path arguments and print out the desired path.