### PR TITLE
Conda mode deprecated from rsconnect-python pkg

### DIFF
--- a/vetiver/rsconnect.py
+++ b/vetiver/rsconnect.py
@@ -19,7 +19,6 @@ def deploy_rsconnect(
     app_id: int = None,
     title: str = None,
     python: str = None,
-    conda_mode: bool = False,
     force_generate: bool = False,
     log_callback: typing.Callable = None,
     image: str = None,
@@ -46,8 +45,6 @@ def deploy_rsconnect(
         Optional title for the deploy.
     python : str
         Optional name of a Python executable
-    conda_mode : bool
-        Use conda to build an environment.yml
     force_generate : bool
         Force generating requirements.txt or environment.yml
     log_callback : typing.Callable
@@ -111,7 +108,6 @@ def deploy_rsconnect(
             app_id=app_id,
             title=title,
             python=python,
-            conda_mode=conda_mode,
             force_generate=force_generate,
             log_callback=log_callback,
             image=image,


### PR DESCRIPTION
In association with PR: rstudio/rsconnect-python#412, the `conda_mode` param is soon to been deprecated. It is still being accepted for the method `deploy_python_fastapi`, but it will not do anything. It is expected to be removed in the future. Passing `true` for this parameter wasn't really supported as Connect has not supported condo environment restoration.

Per the issue referenced above:
>Experimental support for Conda environment was added to rsconnect-python. Connect does not support restoring Conda environments. We should remove the Conda references from rsconnect-python.

This PR fixes: #196 

