### PR TITLE
[MAINT] drop Python 3.7 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,8 @@ jobs:
             python-version: '3.9'
           - os: 'ubuntu-latest'
             python-version: '3.10'
+          - os: 'ubuntu-latest'
+            python-version: '3.11'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,8 +15,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: 'ubuntu-latest'
-            python-version: '3.7'
           - os: 'macos-latest'
             python-version: '3.8'
           - os: 'windows-latest'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,6 @@ jobs:
           python -m pip install spacy
           python -m pip install torch
           python -m pip install statsmodels
-          python -m pip install typing_extensions==4.7.1
       - name: Run Tests
         run: |
           pytest -m 'not rsc_test and not docker' --cov --cov-report xml

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,6 @@ author_email = isabel.zimmerman@posit.co
 license = MIT
 keywords = data, mlops
 classifiers =
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -20,7 +19,7 @@ packages = find:
 include_package_data = True
 zipsafe = False
 
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     numpy
     pandas
@@ -36,7 +35,6 @@ install_requires =
     plotly
     pip-tools
     httpx
-    importlib-metadata>=4.4  # NOTE: Remove when python_requires>=3.8
 
 [options.extras_require]
 all =
@@ -58,7 +56,7 @@ dev =
 
 docs =
     quartodoc
-    griffe==0.25.1
+    griffe==0.32.3
 
 statsmodels =
     statsmodels

--- a/vetiver/tests/test_xgboost.py
+++ b/vetiver/tests/test_xgboost.py
@@ -10,11 +10,7 @@ from fastapi.testclient import TestClient  # noqa
 
 import vetiver  # noqa
 
-# hack since xgboost 2.0 dropped 3.7 support
-if sys.version_info[0] == 3 and sys.version_info[1] < 8:
-    PREDICT_VALUE = 21.064373016357422
-else:
-    PREDICT_VALUE = 19.963224411010742
+PREDICT_VALUE = 19.963224411010742
 
 
 @pytest.fixture


### PR DESCRIPTION
Python 3.7 is EOL, and main dependencies such as FastAPI are beginning to remove support. 