### PR TITLE
[MAINT] bump minimum rsconnect to 1.11.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,6 +63,7 @@ jobs:
           docker-compose up --build -d
           pip freeze > requirements.txt
           make dev
+          cat requirements.txt
         env:
           RSC_LICENSE: ${{ secrets.RSC_LICENSE }}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     nest-asyncio
     requests
     pins>=0.7.1
-    rsconnect-python>=1.21.0
+    rsconnect-python>=1.11.0
     plotly
     pip-tools
     httpx

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     nest-asyncio
     requests
     pins>=0.7.1
-    rsconnect-python>=1.8.0
+    rsconnect-python>=1.21.0
     plotly
     pip-tools
     httpx

--- a/vetiver/rsconnect.py
+++ b/vetiver/rsconnect.py
@@ -108,6 +108,7 @@ def deploy_rsconnect(
             app_id=app_id,
             title=title,
             python=python,
+            conda_mode=False,
             force_generate=force_generate,
             log_callback=log_callback,
             image=image,


### PR DESCRIPTION
If people try to use an older version of rsconnect-python, we no longer supply the `conda_mode` value in `deploy_rsconnect`, so it will fail on deployment.