### PR TITLE
ENH: load dotenv file into generated app.py file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,9 +32,11 @@ install_requires =
     requests
     pins>=0.7.1
     rsconnect-python>=1.11.0
+    python-dotenv
     plotly
     pip-tools
     httpx
+
 
 [options.extras_require]
 all =

--- a/vetiver/tests/test_write_app.py
+++ b/vetiver/tests/test_write_app.py
@@ -26,9 +26,11 @@ def test_write_app(vetiver_model_creation):
         assert (
             contents
             == f"""from vetiver import VetiverModel
+from dotenv import load_dotenv, find_dotenv
 import vetiver
 import pins
 
+load_dotenv(find_dotenv())
 
 b = pins.board_folder({repr(tempdir)}, allow_pickle_read=True)
 v = VetiverModel.from_pin(b, 'model', version = {repr(version)})

--- a/vetiver/write_fastapi.py
+++ b/vetiver/write_fastapi.py
@@ -104,7 +104,9 @@ def write_app(
         f = open(file, "x")
 
     app = f"""from vetiver import VetiverModel
+from dotenv import load_dotenv, find_dotenv
 {_glue_required_pkgs(infra_pkgs)}
+load_dotenv(find_dotenv())
 
 b = pins.{load_board}
 {pin_read}


### PR DESCRIPTION
Automatically load `.env` files into any `app.py` file that is generated. This is particularly useful for authorizing Posit Connect boards.