### PR TITLE
create scaffold polars prototype

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,7 @@ dev =
     pytest-cov
     pytest-snapshot
     vetiver[typecheck]
+    polars
 
 docs =
     quartodoc

--- a/vetiver/prototype.py
+++ b/vetiver/prototype.py
@@ -8,11 +8,17 @@ except ImportError:
 
 import pandas as pd
 import numpy as np
-import polars as pl
 import pydantic
+import typing
 from pydantic import Field
 from warnings import warn
 from .types import create_prototype
+
+if typing.TYPE_CHECKING:
+    try:
+        import polars as pl
+    except ImportError:
+        pl = None
 
 
 class InvalidPTypeError(Exception):

--- a/vetiver/prototype.py
+++ b/vetiver/prototype.py
@@ -9,16 +9,14 @@ except ImportError:
 import pandas as pd
 import numpy as np
 import pydantic
-import typing
 from pydantic import Field
 from warnings import warn
 from .types import create_prototype
 
-if typing.TYPE_CHECKING:
-    try:
-        import polars as pl
-    except ImportError:
-        pl = None
+try:
+    from polars import DataFrame as polars_frame
+except ImportError:
+    polars_frame = None
 
 
 class InvalidPTypeError(Exception):
@@ -131,7 +129,7 @@ def _(data: pd.DataFrame):
 
 
 @vetiver_create_prototype.register
-def _(data: pl.DataFrame):
+def _(data: polars_frame):
     """
     Create input data prototype for a polars dataframe
 

--- a/vetiver/types.py
+++ b/vetiver/types.py
@@ -7,5 +7,9 @@ class Prototype(BaseModel):
     pass
 
 
+class Config:
+    arbitrary_types_allowed = True
+
+
 def create_prototype(**dict_data):
-    return create_model("prototype", __base__=Prototype, **dict_data)
+    return create_model("prototype", __config__=Config, **dict_data)


### PR DESCRIPTION
Notes:

```python
import polars as pl
from vetiver import VetiverModel, VetiverAPI
from vetiver.data import mtcars
from sklearn.linear_model import LinearRegression

schema = {
    "mpg": pl.Float64,
    "cyl": pl.Int32,
    "disp": pl.Float32,
    "hp": int,
    "drat": float,
    "wt": float,
    "qsec": float,
    "vs": bool,
    "am": bool,
    "gear": pl.Int32,
    "carb": int,
}


mtcars = pl.DataFrame(mtcars, schema=schema)

model = LinearRegression().fit(mtcars.drop(columns="mpg"), mtcars["mpg"])
v = VetiverModel(model, model_name = "cars_linear", 
                 prototype_data = mtcars.drop(columns="mpg"))

VetiverAPI(v).run()

```

- right now, this will not coerce or check *polars* types, rather, it will use Python types (eg, if you try to pass "hello" as `cyl`: you get `ValueError: could not convert string to float: 'hello'`)
- need to refactor to not have `polars` as a dependency
- add tests