### PR TITLE
maint: updating code to lessen deprecation warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies  =[
     "numpy",
     "pandas",
     "fastapi",
-    "pydantic",
+    "pydantic>2",
     "joblib",
     "uvicorn",
     "scikit-learn",

--- a/vetiver/prototype.py
+++ b/vetiver/prototype.py
@@ -170,7 +170,7 @@ def _(data: np.ndarray):
     # if its a numpy type, we have to take the Python type due to Pydantic
 
     dict_data = {
-        f"{key}": (type(value.item()), Field(..., example=_item(value)))
+        f"{key}": (type(value.item()), Field(..., examples=[_item(value)]))
         for key, value in dict_data.items()
     }
     prototype = create_prototype(**dict_data)
@@ -197,8 +197,8 @@ def _(data: dict):
                 dict_data.update(
                     {
                         key: (
-                            type(value["example"]),
-                            Field(..., example=value["example"]),
+                            type(value["examples"]),
+                            Field(..., examples=[value["examples"]]),
                         )
                     }
                 )
@@ -242,5 +242,5 @@ def _(data: NoneType):
 def _to_field(data):
     basemodel_input = dict()
     for key, value in data.items():
-        basemodel_input[key] = (type(value), Field(..., example=value))
+        basemodel_input[key] = (type(value), Field(..., examples=[value]))
     return basemodel_input

--- a/vetiver/server.py
+++ b/vetiver/server.py
@@ -366,7 +366,7 @@ def predict(endpoint, data: Union[dict, pd.DataFrame, pd.Series], **kw) -> pd.Da
 
     if isinstance(data, pd.DataFrame):
         response = requester.post(
-            endpoint, data=data.to_json(orient="records"), **kw
+            endpoint, content=data.to_json(orient="records"), **kw
         )  # TO DO: httpx deprecating data in favor of content for TestClient
     elif isinstance(data, pd.Series):
         response = requester.post(endpoint, json=[data.to_dict()], **kw)

--- a/vetiver/templates/model_card.qmd
+++ b/vetiver/templates/model_card.qmd
@@ -45,7 +45,7 @@ A [model card](https://doi.org/10.1145/3287560.3287596) provides brief, transpar
 ```{python}
 #| echo: false
 model_desc = v.description
-num_features = len(v.prototype.construct().dict())
+num_features = len(v.prototype.model_construct().model_dump())
 
 display(Markdown(f"""
 - A {model_desc} using {num_features} feature{'s'[:num_features^1]}.

--- a/vetiver/tests/test_add_endpoint.py
+++ b/vetiver/tests/test_add_endpoint.py
@@ -17,7 +17,7 @@ def data() -> pd.DataFrame:
 
 
 def test_endpoint_adds(client, data):
-    response = client.post("/sum/", data=data.to_json(orient="records"))
+    response = client.post("/sum/", content=data.to_json(orient="records"))
 
     assert response.status_code == 200
     assert response.json() == {"sum": [3, 6, 9]}
@@ -26,7 +26,7 @@ def test_endpoint_adds(client, data):
 def test_endpoint_adds_no_prototype(client_no_prototype, data):
 
     data = pd.DataFrame({"B": [1, 1, 1], "C": [2, 2, 2], "D": [3, 3, 3]})
-    response = client_no_prototype.post("/sum/", data=data.to_json(orient="records"))
+    response = client_no_prototype.post("/sum/", content=data.to_json(orient="records"))
 
     assert response.status_code == 200
     assert response.json() == {"sum": [3, 6, 9]}

--- a/vetiver/tests/test_custom_handler.py
+++ b/vetiver/tests/test_custom_handler.py
@@ -41,7 +41,7 @@ def test_custom_vetiver_model():
     assert not v.metadata.required_pkgs
     assert isinstance(v.model, sklearn.dummy.DummyRegressor)
     # change to model_construct for pydantic v3
-    assert isinstance(v.prototype.construct(), pydantic.BaseModel)
+    assert isinstance(v.prototype.model_construct(), pydantic.BaseModel)
 
 
 def test_custom_vetiver_model_no_ptype():
@@ -60,4 +60,4 @@ def test_custom_vetiver_model_no_ptype():
     assert v.description == "A regression model for testing purposes"
     assert isinstance(v.model, sklearn.dummy.DummyRegressor)
     # change to model_construct for pydantic v3
-    assert isinstance(v.prototype.construct(), pydantic.BaseModel)
+    assert isinstance(v.prototype.model_construct(), pydantic.BaseModel)

--- a/vetiver/tests/test_monitor.py
+++ b/vetiver/tests/test_monitor.py
@@ -9,7 +9,7 @@ import vetiver
 
 import pytest
 
-rng = pd.date_range("1/1/2012", periods=10, freq="S")
+rng = pd.date_range("1/1/2012", periods=10, freq="s")
 new = dict(x=range(len(rng)), y=range(len(rng)))
 df = pd.DataFrame(new, index=rng)
 td = timedelta(seconds=2)

--- a/vetiver/tests/test_prepare_docker.py
+++ b/vetiver/tests/test_prepare_docker.py
@@ -49,7 +49,6 @@ def test_warning_if_no_protocol(create_vetiver_model):
         (("gcs", "gs"), "gcsfs"),
     ],
 )
-@pytest.fixture(scope="module")
 def test_get_board_pkgs(prot, output, create_vetiver_model):
     board = pins.board_temp(allow_pickle_read=True)
     board.fs.protocol = prot

--- a/vetiver/tests/test_server.py
+++ b/vetiver/tests/test_server.py
@@ -43,7 +43,7 @@ def complex_prototype_client():
     v = VetiverModel(
         model=model,
         # move to model_construct for pydantic 3
-        prototype_data=CustomPrototype.construct(),
+        prototype_data=CustomPrototype.model_construct(),
         model_name="my_model",
         versioned=None,
         description="A regression model for testing purposes",
@@ -82,9 +82,9 @@ def test_get_prototype(client, model):
     assert response.status_code == 200, response.text
     assert response.json() == {
         "properties": {
-            "B": {"example": 55, "type": "integer"},
-            "C": {"example": 65, "type": "integer"},
-            "D": {"example": 17, "type": "integer"},
+            "B": {"examples": [55], "type": "integer"},
+            "C": {"examples": [65], "type": "integer"},
+            "D": {"examples": [17], "type": "integer"},
         },
         "required": ["B", "C", "D"],
         "title": "prototype",
@@ -92,8 +92,8 @@ def test_get_prototype(client, model):
     }
 
     assert (
-        model.prototype.construct().dict()
-        == vetiver_create_prototype(response.json()).construct().dict()
+        model.prototype.model_construct().model_dump()
+        == vetiver_create_prototype(response.json()).model_construct().model_dump()
     )
 
 

--- a/vetiver/tests/test_spacy.py
+++ b/vetiver/tests/test_spacy.py
@@ -68,7 +68,7 @@ def test_good_prototype_shape(data, spacy_model):
         model_schema = v.prototype.model_json_schema()
         expected = {
             "properties": {
-                "col": {"example": "1", "title": "Col", "type": "string"},
+                "col": {"examples": "[1]", "title": "Col", "type": "string"},
             },
             "required": ["col"],
             "title": "prototype",
@@ -77,7 +77,7 @@ def test_good_prototype_shape(data, spacy_model):
     except AttributeError:  # pydantic v1
         model_schema = v.prototype.schema_json()
         expected = '{"title": "prototype", "type": "object", "properties": \
-{"col": {"title": "Col", "example": "1", "type": "string"}}, "required": ["col"]}'
+{"col": {"title": "Col", "examples": "[1]", "type": "string"}}, "required": ["col"]}'
 
     assert model_schema == expected
 

--- a/vetiver/tests/test_vetiver_model.py
+++ b/vetiver/tests/test_vetiver_model.py
@@ -45,9 +45,9 @@ def test_vetiver_model_array_prototype():
         json_schema = v.prototype.model_json_schema()
         expected = {
             "properties": {
-                "0": {"example": 96, "title": "0", "type": "integer"},
-                "1": {"example": 11, "title": "1", "type": "integer"},
-                "2": {"example": 33, "title": "2", "type": "integer"},
+                "0": {"examples": [96], "title": "0", "type": "integer"},
+                "1": {"examples": [11], "title": "1", "type": "integer"},
+                "2": {"examples": [33], "title": "2", "type": "integer"},
             },
             "required": ["0", "1", "2"],
             "title": "prototype",
@@ -58,15 +58,15 @@ def test_vetiver_model_array_prototype():
         expected = '{\
 "title": "prototype", \
 "type": "object", \
-"properties": {"0": {"title": "0", "example": 96, "type": "integer"}, \
-"1": {"title": "1", "example": 11, "type": "integer"}, \
-"2": {"title": "2", "example": 33, "type": "integer"}}, \
+"properties": {"0": {"title": "0", "examples": [96], "type": "integer"}, \
+"1": {"title": "1", "examples": [11], "type": "integer"}, \
+"2": {"title": "2", "examples": [33], "type": "integer"}}, \
 "required": ["0", "1", "2"]}'
 
     assert v.model == model
     assert issubclass(v.prototype, vetiver.Prototype)
     # change to model_construct for pydantic v3
-    assert isinstance(v.prototype.construct(), pydantic.BaseModel)
+    assert isinstance(v.prototype.model_construct(), pydantic.BaseModel)
     assert json_schema == expected
 
 
@@ -83,15 +83,15 @@ def test_vetiver_model_dict_like_prototype(prototype_data):
 
     assert v.model == model
     # change to model_construct for pydantic v3
-    assert isinstance(v.prototype.construct(), pydantic.BaseModel)
+    assert isinstance(v.prototype.model_construct(), pydantic.BaseModel)
 
     try:
         json_schema = v.prototype.model_json_schema()
         expected = {
             "properties": {
-                "B": {"example": 96, "title": "B", "type": "integer"},
-                "C": {"example": 11, "title": "C", "type": "integer"},
-                "D": {"example": 33, "title": "D", "type": "integer"},
+                "B": {"examples": [96], "title": "B", "type": "integer"},
+                "C": {"examples": [11], "title": "C", "type": "integer"},
+                "D": {"examples": [33], "title": "D", "type": "integer"},
             },
             "required": ["B", "C", "D"],
             "title": "prototype",
@@ -102,9 +102,9 @@ def test_vetiver_model_dict_like_prototype(prototype_data):
         expected = '{\
 "title": "prototype", \
 "type": "object", \
-"properties": {"B": {"title": "B", "example": 96, "type": "integer"}, \
-"C": {"title": "C", "example": 11, "type": "integer"}, \
-"D": {"title": "D", "example": 33, "type": "integer"}}, \
+"properties": {"B": {"title": "B", "examples": [96], "type": "integer"}, \
+"C": {"title": "C", "examples": [11], "type": "integer"}, \
+"D": {"title": "D", "examples": [33], "type": "integer"}}, \
 "required": ["B", "C", "D"]}'
 
     assert json_schema == expected
@@ -120,9 +120,9 @@ def test_vetiver_model_dict_like_prototype(prototype_data):
             {"B": 0, "C": False, "D": None},
             {
                 "properties": {
-                    "B": {"example": 0, "title": "B", "type": "integer"},
-                    "C": {"example": False, "title": "C", "type": "boolean"},
-                    "D": {"example": None, "title": "D", "type": "null"},
+                    "B": {"examples": [0], "title": "B", "type": "integer"},
+                    "C": {"examples": [False], "title": "C", "type": "boolean"},
+                    "D": {"examples": [None], "title": "D", "type": "null"},
                 },
                 "required": ["B", "C", "D"],
                 "title": "prototype",
@@ -141,7 +141,7 @@ def test_falsy_prototypes(prototype_data, expected):
         metadata=None,
     )
 
-    assert isinstance(v.prototype.construct(), pydantic.BaseModel)
+    assert isinstance(v.prototype.model_construct(), pydantic.BaseModel)
     assert v.prototype.model_json_schema() == expected
 
 
@@ -179,7 +179,7 @@ def test_vetiver_model_from_pin():
     assert isinstance(v2, VetiverModel)
     assert isinstance(v2.model, sklearn.base.BaseEstimator)
     # change to model_construct for pydantic v3
-    assert isinstance(v2.prototype.construct(), pydantic.BaseModel)
+    assert isinstance(v2.prototype.model_construct(), pydantic.BaseModel)
     assert v2.metadata.user == {"test": 123}
     assert v2.metadata.version is not None
     assert v2.metadata.required_pkgs == ["scikit-learn"]
@@ -215,7 +215,7 @@ def test_vetiver_model_from_pin_user_metadata():
     assert isinstance(v2, VetiverModel)
     assert isinstance(v2.model, sklearn.base.BaseEstimator)
     # change to model_construct for pydantic v3
-    assert isinstance(v2.prototype.construct(), pydantic.BaseModel)
+    assert isinstance(v2.prototype.model_construct(), pydantic.BaseModel)
     assert v2.metadata.user == custom_meta
     assert v2.metadata.version is not None
     assert v2.metadata.required_pkgs == loaded_pkgs


### PR DESCRIPTION
There were a handful of warnings piling up in tests, resolving a whole bunch! This PR adds in new restrictions for versions of `fastapi` and `pydantic`. Both of these bounds are about 2 years old, so they shouldn't be too restrictive.

- Supporting Pydantic >2.0
   - With this change, `example`->`examples` in the JSON schema for prototypes ([supported in FastAPI](https://github.com/fastapi/fastapi/blob/e988050f79b32c9444fba8d014d0c69cd7a4b6c7/fastapi/openapi/models.py#L196))
- Supporting FastAPI >0.93  [wip]
    - Allows us to use [lifespan events]()